### PR TITLE
Updated the number of people involved in the Drupal community

### DIFF
--- a/projects/en/drupal.html.twig
+++ b/projects/en/drupal.html.twig
@@ -5,7 +5,7 @@
         of websites and applications. It's built, used, and supported by an
         active and diverse community of people around the world. Drupal is
         open source software maintained and developed by a community of
-        630,000+ users and developers. It's distributed under the terms of the
+        1,000,000+ users and developers. It's distributed under the terms of the
         GNU General Public License (or "GPL"), which means anyone is free to
         download it and share it with others.
 


### PR DESCRIPTION
The original 630,000+ figure comes from the (outdated?) [drupal.org/about](https://drupal.org/about) page. In the [drupal.org](https://drupal.org/) homepage, the (updated?) figure is 1,006,154 people.
