### PR TITLE
Updated irc weekly meetings information

### DIFF
--- a/views/en/community/irc.html.twig
+++ b/views/en/community/irc.html.twig
@@ -12,12 +12,8 @@
     </p>
     <p>
         If you want to see the current Symfony activity or directly want to
-        influence Symfony roadmap, feel free to participate to the
-        <a href="{{ doc_path({
-            'version': 'current',
-            'section': 'contributing',
-            'page':    'community/irc'})
-        }}">weekly IRC meetings event</a>.
+        influence Symfony roadmap, feel free to participate on <a href="irc://irc.freenode.net/symfony-dev">#symfony-dev</a>
+        channel on Freenode.
     </p>
     <p>
         If you want to get in touch with people using symfony to help you in your mother language,


### PR DESCRIPTION
Link to documentation IRC page has been removed. I've updated IRC information and added #symfony-dev channel instead. Regards.
