### PR TITLE
Remove the developer Google group

### DIFF
--- a/views/en/community/mailing_lists.html.twig
+++ b/views/en/community/mailing_lists.html.twig
@@ -25,7 +25,9 @@
 {% block developers %}
     <h3><a href="http://groups.google.com/group/symfony-devs">Developers Group</a></h3>
     <p>
-        If you want to contribute to the project, want to discuss a new feature,
-        consider subscribing to the Symfony developer mailing-list:
+        The developer mailing list is closed as of December 2013. Nevertheless,
+        you can still browse its archive. If you want to contribute to the
+        project or want to discuss a new feature, please refer to the Symfony
+        <a href="https://github.com/symfony/symfony/">GitHub repository</a>.
     </p>
 {% endblock %}


### PR DESCRIPTION
As written by @javiereguiluz in https://groups.google.com/forum/#!topic/symfony-devs/n2n2MH470uI the developers mailing list has been closed.
