### PR TITLE
Reorder IRC page

### DIFF
--- a/views/en/community/irc.html.twig
+++ b/views/en/community/irc.html.twig
@@ -11,11 +11,6 @@
         </ul>
     </p>
     <p>
-        If you want to see the current Symfony activity or directly want to
-        influence Symfony roadmap, feel free to participate on <a href="irc://irc.freenode.net/symfony-dev">#symfony-dev</a>
-        channel on Freenode.
-    </p>
-    <p>
         If you want to get in touch with people using symfony to help you in your mother language,
         connect to the following localized channels :
         <ul>
@@ -32,5 +27,10 @@
     <p>
         Refer to the global <a href="{{ marketing_path('community') }}">community</a> section
         of the symfony website for more ways to get help (mailing-lists, forum...).
+    </p>
+    <p>
+        If you want to see the current Symfony activity or directly want to
+        influence Symfony roadmap, feel free to participate on <a href="irc://irc.freenode.net/symfony-dev">#symfony-dev</a>
+        channel on Freenode.
     </p>
 {% endblock %}


### PR DESCRIPTION
The order was a bit confusing:
- The first paragraph was about the user channel & how to use IRC
- The second about the dev channel
- The third about other user channels
- The fourth about other places to as user questions

Now I moved the paragraph of dev channel to the bottom, so we have a clear seperation of user and dev things.
