### PR TITLE
Removed one undefined HTML entity in the content of one Czech translation

### DIFF
--- a/translations/component.cs.xliff
+++ b/translations/component.cs.xliff
@@ -257,7 +257,7 @@
 
             <trans-unit id="serializer.summary">
                 <source>serializer.summary</source>
-                <target>Převádí objekty do různých formátů (XML, JSON, Yaml, &hellip;) a zpětně z nich je načítá.</target>
+                <target>Převádí objekty do různých formátů (XML, JSON, Yaml, ...) a zpětně z nich je načítá.</target>
             </trans-unit>
             <trans-unit id="serializer.description">
                 <source>serializer.description</source>


### PR DESCRIPTION
As reported in https://github.com/symfony/symfony-marketing/issues/167, switching to the Czech locale resulted in `500 Internal Server Error` on symfony.com.

The cause of this problem was the use of the `&hellip;` HTML entity in one translation:

```
An exception has been thrown during the rendering of a template
("[ERROR 94] Validation failed: no DTD found ! (in n/a - line 2, column 21)
[ERROR 26] Entity 'hellip' not defined (in n/a - line 260, column 86)") in
[...]/menu.html.twig at line 14.
```
