### PR TITLE
Recommend HexChat instead XChat

### DIFF
--- a/views/en/community/irc.html.twig
+++ b/views/en/community/irc.html.twig
@@ -8,7 +8,7 @@
         <ul>
             <li>For Windows, the most common is to use <a href="http://www.mirc.com/">mIRC</a>;</li>
             <li>On Mac, you can easily play with <a href="http://colloquy.info/">Colloquy</a>.</li>
-            <li>For Linux systems there are many IRC Clients, however the most popular are <a href="http://xchat.org/">XChat</a>, <a href="http://chatzilla.hacksrus.com/">Chatzilla</a>, <a href="http://www.irssi.org/">Irssi</a></li>
+            <li>For Linux systems there are many IRC Clients, however the most popular are <a href="http://hexchat.github.io/">HexChat</a>, <a href="http://chatzilla.hacksrus.com/">Chatzilla</a>, <a href="http://www.irssi.org/">Irssi</a></li>
         </ul>
     </p>
     <p>


### PR DESCRIPTION
Active development of XChat stopped 2010.
HexChat is a maintained fork of XChat that should be available in all major linux distributions.
