### PR TITLE
don't promote the #symfony-dev IRC channel

### DIFF
--- a/views/ca/community/irc.html.twig
+++ b/views/ca/community/irc.html.twig
@@ -11,15 +11,6 @@
         </ul>
     </p>
     <p>
-        Si desitges veure l'activitat actual de Symfony o influir directament en 
-        el desenvolupament de Symfony, sent-te lliure de participar en les nostres 
-        <a href="{{ doc_path({
-            'version': 'current',
-            'section': 'contributing',
-            'page':    'community/irc'})
-        }}">trobades setmanals en IRC</a>.
-    </p>
-    <p>
         Si desitges contactar amb gent que utiltza symfony per ajudar-te en la teva llengua nativa, pots
         connectar-te als següent canals localitzats:
         <ul>
@@ -32,7 +23,7 @@
         </ul>
     </p>
     <p>
-    	Consulta la secció de la <a href="{{ marketing_path('community') }}">comunitat mundial</a> 
+    	Consulta la secció de la <a href="{{ marketing_path('community') }}">comunitat mundial</a>
         del lloc de symfony per més formes d'obtenir ajuda (llistes de correu, fòrums, ...).
     </p>
 {% endblock %}

--- a/views/cs/community/irc.html.twig
+++ b/views/cs/community/irc.html.twig
@@ -11,15 +11,6 @@
         </ul>
     </p>
     <p>
-        Pokud chcete mít přehled o aktuálním dění nebo dokonce chcete ovlivnit vývoj Symfony,
-        tak se klidně zúčastněte
-        <a href="{{ doc_path({
-            'version': 'current',
-            'section': 'contributing',
-            'page':    'community/irc'})
-        }}">IRC setkání</a>, které se koná každý týden.
-    </p>
-    <p>
         Pokud chcete navázat kontakt s lidmi používající Symfony, kteří by Vám mohli pomoci ve Vašem
         rodném jazyce, připojte se na některý z uvedených kanálů:
         <ul>

--- a/views/de/community/irc.html.twig
+++ b/views/de/community/irc.html.twig
@@ -12,15 +12,6 @@
         </ul>
     </p>
     <p>
-        Wenn Sie über das aktuelle Geschehen rund um Symfony im Bilde sein oder zur Weiterentwicklung von Symfony
-        beitragen wollen, sind Sie herzlich eingeladen, an den
-        <a href="{{ doc_path({
-            'version': 'current',
-            'section': 'contributing',
-            'page':    'community/irc'})
-        }}">wöchentlichen IRC-Meetings</a> teilzunehmen.
-    </p>
-    <p>
         Mehrsprachige Unterstützung zu Symfony erhalten Sie in einem der folgenden IRC-Channels:
         <ul>
             <li>Brasilianisches Portugiesisch: <a href="irc://irc.freenode.net/symfony.br">#symfony.br</a></li>

--- a/views/en/community/irc.html.twig
+++ b/views/en/community/irc.html.twig
@@ -29,9 +29,4 @@
         Refer to the global <a href="{{ marketing_path('community') }}">community</a> section
         of the symfony website for more ways to get help (mailing-lists, forum...).
     </p>
-    <p>
-        If you want to see the current Symfony activity or directly want to
-        influence Symfony roadmap, feel free to participate on <a href="irc://irc.freenode.net/symfony-dev">#symfony-dev</a>
-        channel on Freenode.
-    </p>
 {% endblock %}

--- a/views/es/community/irc.html.twig
+++ b/views/es/community/irc.html.twig
@@ -11,15 +11,6 @@
         </ul>
     </p>
     <p>
-    	Si deseas ver la actividad actual de Symfony o influir directamente 
-    	en su desarrollo, siéntete libre de participar en nuestros
-        <a href="{{ doc_path({
-            'version': 'current',
-            'section': 'contributing',
-            'page':    'community/irc'})
-        }}">encuentros semanales en IRC</a>.
-    </p>
-    <p>
     	Si deseas contactarte con gente que utilza symfony para ayudarte en tu lengua nativa, puedes
     	conectarte a los siguiente canales localizados:
         <ul>
@@ -34,7 +25,7 @@
         </ul>
     </p>
     <p>
-    	Consulte la sección de la <a href="{{ marketing_path('community') }}">comunidad mundial</a> 
+    	Consulte la sección de la <a href="{{ marketing_path('community') }}">comunidad mundial</a>
     	del sitio de symfony para más formas de obtener ayuda (listas de correo, foros, ...).
     </p>
 {% endblock %}

--- a/views/fr/community/irc.html.twig
+++ b/views/fr/community/irc.html.twig
@@ -32,11 +32,4 @@
         sur le site de Symfony pour obtenir de l'aide sur d'autres supports
         (mailing lists, forum...).
     </p>
-    <p>
-        Si vous voulez voir ce qui se trame actuellement sur Symfony ou si vous
-        voulez directement influencer les prochaines directives, n'hésitez pas à
-        participer sur le canal
-        <a href="irc://irc.freenode.net/symfony-dev">#symfony-dev</a> sur
-        Freenode.
-    </p>
 {% endblock %}

--- a/views/hu/community/irc.html.twig
+++ b/views/hu/community/irc.html.twig
@@ -11,15 +11,6 @@
         </ul>
     </p>
     <p>
-        Ha szeretnél bepillantani az aktuális symfonys történésekbe,
-        vagy szeretnéd tevékenyen befolyásolni az eseményeket, bátran vegyél részt a
-        <a href="{{ doc_path({
-            'version': 'current',
-            'section': 'contributing',
-            'page':    'community/irc'})
-        }}">heti IRC-s megbeszéléseken</a>.
-    </p>
-    <p>
         Ha más nyelven keresnél symfonys segítséget, nézd meg ezeket a csatornákat:
         <ul>
             <li>brazíliai portugál: <a href="irc://irc.freenode.net/symfony.br">#symfony.br</a></li>

--- a/views/pl/community/irc.html.twig
+++ b/views/pl/community/irc.html.twig
@@ -11,16 +11,7 @@
         </ul>
     </p>
     <p>
-        Jeśli chcesz śledzić aktywność społeczności Symfony, albo mieć wpływ na plan rozwoju, 
-        dołącz do cotygodniowych spotkań na IRCu.
-        <a href="{{ doc_path({
-            'version': 'current',
-            'section': 'contributing',
-            'page':    'community/irc'})
-        }}">cotygodniowych spotkaniach na IRC</a>.
-    </p>
-    <p>
-        Jeśli chcesz poznać innych użytkowników Symfony mówiących w Twoim ojczystym języku, 
+        Jeśli chcesz poznać innych użytkowników Symfony mówiących w Twoim ojczystym języku,
         wejdź na jeden z poniższych kanałów:
         <ul>
             <li>Portugalski (Brazylia): <a href="irc://irc.freenode.net/symfony.br">#symfony.br</a></li>
@@ -34,7 +25,7 @@
     </p>
     <p>
         Aby znaleźć więcej informacji (listy dysksyjne, forum, itp.) odwiedź dział
-        <a href="{{ marketing_path('community') }}">społeczność</a> na stronie 
+        <a href="{{ marketing_path('community') }}">społeczność</a> na stronie
         internetowej symfony.
     </p>
 {% endblock %}

--- a/views/pt/community/irc.html.twig
+++ b/views/pt/community/irc.html.twig
@@ -13,15 +13,6 @@
         </ul>
     </p>
     <p>
-        Se você quiser estar ocurrente da atividade do Symfony ou influenciar
-        diretamente o roadmap, esteja à vontade para participar nas
-        <a href="{{ doc_path({
-            'version': 'current',
-            'section': 'contributing',
-            'page':    'community/irc'})
-        }}"> reuniões semanais no IRC</a>.
-    </p>
-    <p>
         Se você quiser entrar em contato com pessoas que usam o Symfony para procurar ajuda
         e que falam a sua língua nativa, pode conectar-se aos seguintes canais no IRC:
         <ul>

--- a/views/pt_BR/community/irc.html.twig
+++ b/views/pt_BR/community/irc.html.twig
@@ -11,15 +11,6 @@
         </ul>
     </p>
     <p>
-        Se você quiser verificar a atividade atual do Symfony ou influenciar
-        diretamente o roadmap, esteja à vontade para participar nas
-        <a href="{{ doc_path({
-            'version': 'current',
-            'section': 'contributing',
-            'page':    'community/irc'})
-        }}">reuniões semanais no IRC</a>.
-    </p>
-    <p>
         Se você quiser entrar em contato com pessoas que usam o Symfony, para procurar ajuda
         e que falam a sua língua nativa, pode conectar-se aos seguintes canais no IRC:
         <ul>

--- a/views/sk/community/irc.html.twig
+++ b/views/sk/community/irc.html.twig
@@ -11,15 +11,6 @@
         </ul>
     </p>
     <p>
-        Ak chcete mať aktuálny prehľad o Symfony alebo chcete priamo ovplyvniť
-        Symfony plány, pokojne sa zúčastnite
-        <a href="{{ doc_path({
-            'version': 'current',
-            'section': 'contributing',
-            'page':    'community/irc'})
-        }}">IRC stretnutia</a>, ktoré sa koná raz za týždeň.
-    </p>
-    <p>
         Ak sa chcete skonaktovať s luďmi používajúcimi Symfony, ktorí Vám pomôžu vo Vašom materinskom
         jazyku, pripojte sa na niektorý lokálny IRC kanál :
         <ul>

--- a/views/sl/community/irc.html.twig
+++ b/views/sl/community/irc.html.twig
@@ -29,9 +29,4 @@
         Glejte globalno sekcijo <a href="{{ marketing_path('community') }}">skupnost</a>
         strani symfony za več načinov pomoči (dopisni seznami, forum ...).
     </p>
-    <p>
-        Če želite videti trenutne Symfony dejavnosti, ali želite neposredno
-        vplivati na načrt Symfony, lahko prosto sodelujete na <a href="irc://irc.freenode.net/symfony-dev">#symfony-dev</a>
-        kanalu na Freenode.
-    </p>
 {% endblock %}

--- a/views/zh_CN/community/irc.html.twig
+++ b/views/zh_CN/community/irc.html.twig
@@ -11,14 +11,6 @@
         </ul>
     </p>
     <p>
-        您若希望查阅目前 Symfony 的状况或想参与指导 Symfony 技术路线，请参加
-        <a href="{{ doc_path({
-            'version': 'current',
-            'section': 'contributing',
-            'page':    'community/irc'})
-        }}">每周的 IRC 会议</a>。
-    </p>
-    <p>
         您若希望和讲您母语人士保持联系或获得帮助，请连接到以下频道：
         <ul>
             <li>葡萄牙语（巴西）：<a href="irc://irc.freenode.net/symfony.br">#symfony.br</a></li>


### PR DESCRIPTION
No active communication is taking place in #symfony-dev on Freenode. Therefore, it's better not to promote it on symfony.com.
