### PR TITLE
update thelia components and move its position

### DIFF
--- a/projects/_projects.yml
+++ b/projects/_projects.yml
@@ -7,6 +7,7 @@ highlighted:
     - composer
     - magento
     - piwik
+    - thelia
     - symfonyfs
 major:
     - silex
@@ -31,7 +32,6 @@ major:
     - mautic
     - freepost
 minor:
-    - thelia
     - kunstmaanbundles
     - sculpin
     - flow

--- a/projects/thelia.yml
+++ b/projects/thelia.yml
@@ -2,6 +2,7 @@ name: Thelia
 url: http://thelia.net
 dependencies: []
 components:
+    - BrowserKit
     - ClassLoader
     - Config
     - Console
@@ -10,6 +11,7 @@ components:
     - Filesystem
     - Finder
     - Form
+    - HttpFoudation
     - HttpKernel
     - Icu
     - Routing


### PR DESCRIPTION
Hi,

I updated the list of components used by Thelia.

Thelia is no longer a minor project. Thelia is stable since a year and had been present in many symfony events so I changed its position.

Thanks