### PR TITLE
Don't promote HTTPS for installing the installer (it doesn't work yet)

### DIFF
--- a/views/en/what_is_symfony/download.html.twig
+++ b/views/en/what_is_symfony/download.html.twig
@@ -29,13 +29,13 @@
 
 {% block linux_mac_installation_title %}Installation on Linux and Mac OS X{% endblock %}
 {% block linux_mac_installation_commands %}
-    $ sudo curl -LsS https://symfony.com/installer -o /usr/local/bin/symfony<br/>
+    $ sudo curl -LsS http://symfony.com/installer -o /usr/local/bin/symfony<br/>
     $ sudo chmod a+x /usr/local/bin/symfony
 {% endblock %}
 
 {% block windows_installation_title %}Installation on Windows{% endblock %}
 {% block windows_installation_commands %}
-    c:\> php -r "readfile('https://symfony.com/installer');" > symfony
+    c:\> php -r "readfile('http://symfony.com/installer');" > symfony
 {% endblock %}
 {% block windows_installation_instructions %}
     <p>


### PR DESCRIPTION
HTTPS support is not enabled in `get.sensiolabs.org` server yet. As reported in https://github.com/symfony/symfony-installer/issues/160 this is causing troubles to our users. While we fix this issue in our infrastructure, it's better to recommend the use of plain HTTP.