### PR TITLE
Added the Symfony Guard component

### DIFF
--- a/projects/_components.yml
+++ b/projects/_components.yml
@@ -12,6 +12,7 @@ ExpressionLanguage:  { docUrl: expression_language/index.html  }
 Filesystem:          { docUrl: filesystem.html                 }
 Finder:              { docUrl: finder.html                     }
 Form:                { docUrl: form/index.html                 }
+Guard:               { docUrl: ~                               }
 HttpFoundation:      { docUrl: http_foundation/index.html      }
 HttpKernel:          { docUrl: http_kernel/index.html          }
 Icu:                 { docUrl: ~                               }

--- a/translations/component.en.xliff
+++ b/translations/component.en.xliff
@@ -174,6 +174,15 @@
                 <target />
             </trans-unit>
 
+            <trans-unit id="guard.summary">
+                <source>guard.summary</source>
+                <target>Brings many layers of authentication together, making it much easier to create complex authentication systems where you have total control.</target>
+            </trans-unit>
+            <trans-unit id="guard.description">
+                <source>guard.description</source>
+                <target />
+            </trans-unit>
+
             <trans-unit id="httpfoundation.summary">
                 <source>httpfoundation.summary</source>
                 <target>Defines an object-oriented layer for the HTTP specification.</target>


### PR DESCRIPTION
Before merging this change, we need to settle on the official name of the component:

  * The URL is "security-guard" (https://github.com/symfony/security-guard)
  * The title of the component doc is "Security Component - Guard"
  * The description of the component talks about "The Guard component"

cc @weaverryan