### PR TITLE
Adding Symfony Empty Edition

### DIFF
--- a/views/en/what_is_symfony/distributions.html.twig
+++ b/views/en/what_is_symfony/distributions.html.twig
@@ -48,5 +48,10 @@
             shows how to build an application that provides a RESTful API using the
             <a href="https://github.com/FriendsOfSymfony/FOSRestBundle">FOSRestBundle</a> and several other related Bundles.
         </li>
+        <li>
+            <a href="https://github.com/gnugat/symfony-empty-edition">Symfony Empty Edition</a>
+            is provided without any libraries or bundles (except for Symfony's FrameworkBundle)
+            allowing you to only include the dependencies you need.
+        </li>
     </ul>
 {% endblock %}


### PR DESCRIPTION
The [Symfony Empty Edition](https://github.com/gnugat/symfony-empty-edition) is a blank canvas: it includes the strict minimum (`FrameworkBundle`) to allow you to build a custom made application with only the dependencies you need.