### PR TITLE
Updated component translations after their repository renaming

### DIFF
--- a/translations/component.cs.xliff
+++ b/translations/component.cs.xliff
@@ -48,265 +48,149 @@
                 <target>Dokumentace</target>
             </trans-unit>
 
-            <trans-unit id="browserkit.summary">
-                <source>browserkit.summary</source>
+            <trans-unit id="browser-kit.summary">
+                <source>browser-kit.summary</source>
                 <target>Simuluje chování webového prohlížeče.</target>
             </trans-unit>
-            <trans-unit id="browserkit.description">
-                <source>browserkit.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="classloader.summary">
-                <source>classloader.summary</source>
+            <trans-unit id="class-loader.summary">
+                <source>class-loader.summary</source>
                 <target>Automaticky načítá soubory s třídami, pokud se dodržuje některá ze standardních PHP konvencí.</target>
-            </trans-unit>
-            <trans-unit id="6">
-                <source>classloader.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="config.summary">
                 <source>config.summary</source>
                 <target>Pomáhá vyhledat, načíst, spojit, automaticky vyplnit a zkontrolovat konfiguraci.</target>
             </trans-unit>
-            <trans-unit id="config.description">
-                <source>config.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="console.summary">
                 <source>console.summary</source>
                 <target>Usnadňuje vytváření krásných a testovatelných aplikací pro příkazovou řádku.</target>
             </trans-unit>
-            <trans-unit id="console.description">
-                <source>console.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="cssselector.summary">
-                <source>cssselector.summary</source>
+            <trans-unit id="css-selector.summary">
+                <source>css-selector.summary</source>
                 <target>Převádí CSS selektory na XPath výrazy.</target>
-            </trans-unit>
-            <trans-unit id="cssselector.description">
-                <source>cssselector.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="debug.summary">
                 <source>debug.summary</source>
                 <target>Poskytuje nástroje pro snadnější ladění PHP kódu.</target>
             </trans-unit>
-            <trans-unit id="debug.description">
-                <source>debug.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="dependencyinjection.summary">
-                <source>dependencyinjection.summary</source>
+            <trans-unit id="dependency-injection.summary">
+                <source>dependency-injection.summary</source>
                 <target>Umožňuje standardizovat a centralizovat způsob vytváření objektů v aplikaci.</target>
             </trans-unit>
-            <trans-unit id="dependencyinjection.description">
-                <source>dependencyinjection.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="domcrawler.summary">
-                <source>domcrawler.summary</source>
+            <trans-unit id="dom-crawler.summary">
+                <source>dom-crawler.summary</source>
                 <target>Usnadňuje procházení DOM struktury HTML a XML dokumentů.</target>
             </trans-unit>
-            <trans-unit id="domcrawler.description">
-                <source>domcrawler.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="eventdispatcher.summary">
-                <source>eventdispatcher.summary</source>
+            <trans-unit id="event-dispatcher.summary">
+                <source>event-dispatcher.summary</source>
                 <target>Implementuje návrhový vzor Observer (Pozorovatel).</target>
             </trans-unit>
-            <trans-unit id="eventdispatcher.description">
-                <source>eventdispatcher.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="expressionlanguage.summary">
-                <source>expressionlanguage.summary</source>
+            <trans-unit id="expression-language.summary">
+                <source>expression-language.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="expressionlanguage.description">
-                <source>expressionlanguage.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="filesystem.summary">
                 <source>filesystem.summary</source>
                 <target>Poskytuje základní nástroje pro práci se soubory a adresáři.</target>
             </trans-unit>
-            <trans-unit id="filesystem.description">
-                <source>filesystem.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="finder.summary">
                 <source>finder.summary</source>
                 <target>Vyhledává soubory a adresáře pomocí intuitivního a přehledného zápisu.</target>
-            </trans-unit>
-            <trans-unit id="finder.description">
-                <source>finder.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="form.summary">
                 <source>form.summary</source>
                 <target></target>
             </trans-unit>
-            <trans-unit id="form.description">
-                <source>form.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpfoundation.summary">
-                <source>httpfoundation.summary</source>
+            <trans-unit id="http-foundation.summary">
+                <source>http-foundation.summary</source>
                 <target>Definuje objektově orientovanou vrstvu pro práci s HTTP protokolem.</target>
             </trans-unit>
-            <trans-unit id="httpfoundation.description">
-                <source>httpfoundation.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpkernel.summary">
-                <source>httpkernel.summary</source>
+            <trans-unit id="http-kernel.summary">
+                <source>http-kernel.summary</source>
                 <target>Poskytuje základní stavební prvky pro vytvoření rychlého a flexibilního frameworku založeném na HTTP protokolu.</target>
-            </trans-unit>
-            <trans-unit id="httpkernel.description">
-                <source>httpkernel.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="locale.summary">
                 <source>locale.summary</source>
                 <target>Obsahuje kód pro případ, že není v PHP dostupné intl rozšíření. Tato komponenta je zastaralá od verze 2.3 a místo ní se používá Intl komponenta.</target>
             </trans-unit>
-            <trans-unit id="locale.description">
-                <source>locale.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="intl.summary">
                 <source>intl.summary</source>
                 <target>Obsahuje kód pro případ, že není v PHP dostupné intl rozšíření.</target>
-            </trans-unit>
-            <trans-unit id="intl.description">
-                <source>intl.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="icu.summary">
                 <source>icu.summary</source>
                 <target>Obsahuje data pro různé verze ICU knihovny, která se používají přes API Intl komponenty.</target>
             </trans-unit>
-            <trans-unit id="icu.description">
-                <source>icu.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="optionsresolver.summary">
-                <source>optionsresolver.summary</source>
+            <trans-unit id="options-resolver.summary">
+                <source>options-resolver.summary</source>
                 <target>Pomáhá nakonfigurovat objekty pomocí definice obsažené v obyčejném poli.</target>
-            </trans-unit>
-            <trans-unit id="optionsresolver.description">
-                <source>optionsresolver.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="process.summary">
                 <source>process.summary</source>
                 <target>Spouští příkazy v dalším procesu.</target>
             </trans-unit>
-            <trans-unit id="process.description">
-                <source>process.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="propertyaccess.summary">
-                <source>propertyaccess.summary</source>
+            <trans-unit id="property-access.summary">
+                <source>property-access.summary</source>
                 <target>Poskytuje funkce pro čtení a zápis hodnot z objektů a polí pomocí jednoduchého textového zápisu.</target>
-            </trans-unit>
-            <trans-unit id="propertyaccess.description">
-                <source>propertyaccess.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="routing.summary">
                 <source>routing.summary</source>
                 <target>Převádí HTTP požadavek na sadu konfiguračních proměnných.</target>
             </trans-unit>
-            <trans-unit id="routing.description">
-                <source>routing.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="security.summary">
                 <source>security.summary</source>
                 <target>Poskytuje infrastrukturu pro propracované autorizační systémy.</target>
-            </trans-unit>
-            <trans-unit id="security.description">
-                <source>security.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="serializer.summary">
                 <source>serializer.summary</source>
                 <target>Převádí objekty do různých formátů (XML, JSON, Yaml, ...) a zpětně z nich je načítá.</target>
             </trans-unit>
-            <trans-unit id="serializer.description">
-                <source>serializer.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="stopwatch.summary">
                 <source>stopwatch.summary</source>
                 <target>Umožňuje profilovat kód.</target>
-            </trans-unit>
-            <trans-unit id="stopwatch.description">
-                <source>stopwatch.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="templating.summary">
                 <source>templating.summary</source>
                 <target>Poskytuje veškeré nástroje pro začlenění jakéhokoliv šablonovacího systému.</target>
             </trans-unit>
-            <trans-unit id="templating.description">
-                <source>templating.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="translation.summary">
                 <source>translation.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="translation.description">
-                <source>translation.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="validator.summary">
                 <source>validator.summary</source>
                 <target></target>
             </trans-unit>
-            <trans-unit id="validator.description">
-                <source>validator.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="yaml.summary">
                 <source>yaml.summary</source>
                 <target>Načítá data z YAML souborů a ukládá je do nich.</target>
-            </trans-unit>
-            <trans-unit id="yaml.description">
-                <source>yaml.description</source>
-                <target />
             </trans-unit>
         </body>
     </file>

--- a/translations/component.de.xliff
+++ b/translations/component.de.xliff
@@ -48,8 +48,8 @@
                 <target>Dokumentation</target>
             </trans-unit>
 
-            <trans-unit id="browserkit.summary">
-                <source>browserkit.summary</source>
+            <trans-unit id="browser-kit.summary">
+                <source>browser-kit.summary</source>
                 <target>Simuliert das Verhalten eines Web-Browsers</target>
             </trans-unit>
             <trans-unit id="browserkit.description">
@@ -57,8 +57,8 @@
                 <target></target>
             </trans-unit>
 
-            <trans-unit id="classloader.summary">
-                <source>classloader.summary</source>
+            <trans-unit id="class-loader.summary">
+                <source>class-loader.summary</source>
                 <target>Lädt die Klassen eines Projektes, sofern diese bestimmte PHP-Konventionen erfüllen</target>
             </trans-unit>
             <trans-unit id="6">
@@ -70,10 +70,6 @@
                 <source>config.summary</source>
                 <target>Unterstützt das Finden, Laden, Zusammenführen, Vervollständigen und Validieren von Konfigurationswerten</target>
             </trans-unit>
-            <trans-unit id="config.description">
-                <source>config.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="console.summary">
                 <source>console.summary</source>
@@ -84,229 +80,129 @@
                 <target></target>
             </trans-unit>
 
-            <trans-unit id="cssselector.summary">
-                <source>cssselector.summary</source>
+            <trans-unit id="css-selector.summary">
+                <source>css-selector.summary</source>
                 <target>Wandelt CSS-Selektoren in XPath-Ausdrücke um</target>
-            </trans-unit>
-            <trans-unit id="cssselector.description">
-                <source>cssselector.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="debug.summary">
                 <source>debug.summary</source>
                 <target>Stellt Werkzeuge zum vereinfachten Debugging von PHP-Code bereit</target>
             </trans-unit>
-            <trans-unit id="debug.description">
-                <source>debug.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="dependencyinjection.summary">
-                <source>dependencyinjection.summary</source>
+            <trans-unit id="dependency-injection.summary">
+                <source>dependency-injection.summary</source>
                 <target>Ermöglicht die Konstruktion von Objekten in einer Anwendung zu standardisieren und zentralisieren</target>
             </trans-unit>
-            <trans-unit id="dependencyinjection.description">
-                <source>dependencyinjection.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="domcrawler.summary">
-                <source>domcrawler.summary</source>
+            <trans-unit id="dom-crawler.summary">
+                <source>dom-crawler.summary</source>
                 <target>Erlaubt die Navigation innerhalb des DOM von HTML- und XML-Dokumenten</target>
             </trans-unit>
-            <trans-unit id="domcrawler.description">
-                <source>domcrawler.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="eventdispatcher.summary">
-                <source>eventdispatcher.summary</source>
+            <trans-unit id="event-dispatcher.summary">
+                <source>event-dispatcher.summary</source>
                 <target>Implementiert eine schlanke Version des Observer-Design Patterns</target>
             </trans-unit>
-            <trans-unit id="eventdispatcher.description">
-                <source>eventdispatcher.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="expressionlanguage.summary">
-                <source>expressionlanguage.summary</source>
+            <trans-unit id="expression-language.summary">
+                <source>expression-language.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="expressionlanguage.description">
-                <source>expressionlanguage.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="filesystem.summary">
                 <source>filesystem.summary</source>
                 <target>Erlaubt den Zugriff und die Interaktion mit dem Dateisystem</target>
             </trans-unit>
-            <trans-unit id="filesystem.description">
-                <source>filesystem.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="finder.summary">
                 <source>finder.summary</source>
                 <target>Findet Dateien und Verzeichnisse mittels eines Fluent Interface</target>
-            </trans-unit>
-            <trans-unit id="finder.description">
-                <source>finder.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="form.summary">
                 <source>form.summary</source>
                 <target>Erstellt und verarbeitet Formulare</target>
             </trans-unit>
-            <trans-unit id="form.description">
-                <source>form.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpfoundation.summary">
-                <source>httpfoundation.summary</source>
+            <trans-unit id="http-foundation.summary">
+                <source>http-foundation.summary</source>
                 <target>Bildet die HTTP-Spezifikation als objektorientierte Schnittstelle ab</target>
             </trans-unit>
-            <trans-unit id="httpfoundation.description">
-                <source>httpfoundation.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpkernel.summary">
-                <source>httpkernel.summary</source>
+            <trans-unit id="http-kernel.summary">
+                <source>http-kernel.summary</source>
                 <target>Stellt die Grundbausteine flexibler und schneller HTTP-basierter Frameworks bereit</target>
-            </trans-unit>
-            <trans-unit id="httpkernel.description">
-                <source>httpkernel.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="locale.summary">
                 <source>locale.summary</source>
                 <target>Stellt Hilfscode für Lokalisierung zur Verfügung, falls die PHP-Erweiterung intl nicht verfügbar ist. Diese Komponente gilt ab Version 2.3 als veraltet, bitte nutzen Sie stattdessen die Komponente Intl</target>
             </trans-unit>
-            <trans-unit id="locale.description">
-                <source>locale.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="intl.summary">
                 <source>intl.summary</source>
                 <target>Stellt Hilfscode für Lokalisierung zur Verfügung, falls die PHP-Erweiterung intl nicht verfügbar ist</target>
-            </trans-unit>
-            <trans-unit id="intl.description">
-                <source>intl.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="icu.summary">
                 <source>icu.summary</source>
                 <target>Enthält die Daten der ICU-Bibliothek in einer angepassten Version, zur Nutzung über die API der Komponente</target>
             </trans-unit>
-            <trans-unit id="icu.description">
-                <source>icu.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="optionsresolver.summary">
-                <source>optionsresolver.summary</source>
+            <trans-unit id="options-resolver.summary">
+                <source>options-resolver.summary</source>
                 <target>Erlaubt die Konfiguration von Objekten mittels Options-Arrays</target>
-            </trans-unit>
-            <trans-unit id="optionsresolver.description">
-                <source>optionsresolver.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="process.summary">
                 <source>process.summary</source>
                 <target>Führt Befehle in Subprozessen aus</target>
             </trans-unit>
-            <trans-unit id="process.description">
-                <source>process.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="propertyaccess.summary">
-                <source>propertyaccess.summary</source>
+            <trans-unit id="property-access.summary">
+                <source>property-access.summary</source>
                 <target>Erlaubt das Lesen und Schreiben auf Objekten oder Arrays über eine einfache String-Notation</target>
-            </trans-unit>
-            <trans-unit id="propertyaccess.description">
-                <source>propertyaccess.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="routing.summary">
                 <source>routing.summary</source>
                 <target>Überträgt einen HTTP-Request auf Konfigurationsvariablen</target>
             </trans-unit>
-            <trans-unit id="routing.description">
-                <source>routing.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="security.summary">
                 <source>security.summary</source>
                 <target>Stellt die Infrastruktur für fortgeschrittene Authorisierungssysteme bereit</target>
-            </trans-unit>
-            <trans-unit id="security.description">
-                <source>security.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="serializer.summary">
                 <source>serializer.summary</source>
                 <target>Wandelt Objekte zwischen PHP und Formaten wie XML, JSON, Yaml um</target>
             </trans-unit>
-            <trans-unit id="serializer.description">
-                <source>serializer.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="stopwatch.summary">
                 <source>stopwatch.summary</source>
                 <target>Stellt Funktionen zum Profiling von Code zur Verfügung</target>
-            </trans-unit>
-            <trans-unit id="stopwatch.description">
-                <source>stopwatch.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="templating.summary">
                 <source>templating.summary</source>
                 <target>Stellt alle Werkzeuge zum Erstellen eines Template-System bereit</target>
             </trans-unit>
-            <trans-unit id="templating.description">
-                <source>templating.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="translation.summary">
                 <source>translation.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="translation.description">
-                <source>translation.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="validator.summary">
                 <source>validator.summary</source>
                 <target></target>
             </trans-unit>
-            <trans-unit id="validator.description">
-                <source>validator.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="yaml.summary">
                 <source>yaml.summary</source>
                 <target>Liest und generiert YAML-Dateien</target>
-            </trans-unit>
-            <trans-unit id="yaml.description">
-                <source>yaml.description</source>
-                <target />
             </trans-unit>
         </body>
     </file>

--- a/translations/component.en.xliff
+++ b/translations/component.en.xliff
@@ -52,306 +52,170 @@
                 <source>asset.summary</source>
                 <target>Manages URL generation and versioning of web assets such as CSS stylesheets, JavaScript files and image files.</target>
             </trans-unit>
-            <trans-unit id="asset.description">
-                <source>asset.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="browserkit.summary">
-                <source>browserkit.summary</source>
+            <trans-unit id="browser-kit.summary">
+                <source>browser-kit.summary</source>
                 <target>Simulates the behavior of a web browser.</target>
             </trans-unit>
-            <trans-unit id="browserkit.description">
-                <source>browserkit.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="classloader.summary">
-                <source>classloader.summary</source>
+            <trans-unit id="class-loader.summary">
+                <source>class-loader.summary</source>
                 <target>Loads your project classes automatically if they follow some standard PHP conventions.</target>
-            </trans-unit>
-            <trans-unit id="6">
-                <source>classloader.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="config.summary">
                 <source>config.summary</source>
                 <target>Helps you find, load, combine, autofill and validate configuration values.</target>
             </trans-unit>
-            <trans-unit id="config.description">
-                <source>config.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="console.summary">
                 <source>console.summary</source>
                 <target>Eases the creation of beautiful and testable command line interfaces.</target>
             </trans-unit>
-            <trans-unit id="console.description">
-                <source>console.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="cssselector.summary">
-                <source>cssselector.summary</source>
+            <trans-unit id="css-selector.summary">
+                <source>css-selector.summary</source>
                 <target>Converts CSS selectors to XPath expressions.</target>
-            </trans-unit>
-            <trans-unit id="cssselector.description">
-                <source>cssselector.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="debug.summary">
                 <source>debug.summary</source>
                 <target>Provides tools to ease debugging PHP code.</target>
             </trans-unit>
-            <trans-unit id="debug.description">
-                <source>debug.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="dependencyinjection.summary">
-                <source>dependencyinjection.summary</source>
+            <trans-unit id="dependency-injection.summary">
+                <source>dependency-injection.summary</source>
                 <target>Allows you to standardize and centralize the way objects are constructed in your application.</target>
             </trans-unit>
-            <trans-unit id="dependencyinjection.description">
-                <source>dependencyinjection.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="domcrawler.summary">
-                <source>domcrawler.summary</source>
+            <trans-unit id="dom-crawler.summary">
+                <source>dom-crawler.summary</source>
                 <target>Eases DOM navigation for HTML and XML documents.</target>
             </trans-unit>
-            <trans-unit id="domcrawler.description">
-                <source>domcrawler.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="eventdispatcher.summary">
-                <source>eventdispatcher.summary</source>
+            <trans-unit id="event-dispatcher.summary">
+                <source>event-dispatcher.summary</source>
                 <target>Implements the Mediator pattern in a simple and effective way to make projects truly extensible.</target>
             </trans-unit>
-            <trans-unit id="eventdispatcher.description">
-                <source>eventdispatcher.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="expressionlanguage.summary">
-                <source>expressionlanguage.summary</source>
+            <trans-unit id="expression-language.summary">
+                <source>expression-language.summary</source>
                 <target>Provides an engine that can compile and evaluate expressions.</target>
-            </trans-unit>
-            <trans-unit id="expressionlanguage.description">
-                <source>expressionlanguage.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="filesystem.summary">
                 <source>filesystem.summary</source>
                 <target>Provides basic utilities for the filesystem.</target>
             </trans-unit>
-            <trans-unit id="filesystem.description">
-                <source>filesystem.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="finder.summary">
                 <source>finder.summary</source>
                 <target>Finds files and directories via an intuitive fluent interface.</target>
-            </trans-unit>
-            <trans-unit id="finder.description">
-                <source>finder.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="form.summary">
                 <source>form.summary</source>
                 <target>Provides tools to easy creating, processing and reusing HTML forms.</target>
             </trans-unit>
-            <trans-unit id="form.description">
-                <source>form.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="guard.summary">
                 <source>guard.summary</source>
                 <target>Brings many layers of authentication together, making it much easier to create complex authentication systems where you have total control.</target>
             </trans-unit>
-            <trans-unit id="guard.description">
-                <source>guard.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpfoundation.summary">
-                <source>httpfoundation.summary</source>
+            <trans-unit id="http-foundation.summary">
+                <source>http-foundation.summary</source>
                 <target>Defines an object-oriented layer for the HTTP specification.</target>
             </trans-unit>
-            <trans-unit id="httpfoundation.description">
-                <source>httpfoundation.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpkernel.summary">
-                <source>httpkernel.summary</source>
+            <trans-unit id="http-kernel.summary">
+                <source>http-kernel.summary</source>
                 <target>Provides the building blocks to create flexible and fast HTTP-based frameworks.</target>
-            </trans-unit>
-            <trans-unit id="httpkernel.description">
-                <source>httpkernel.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="ldap.summary">
                 <source>ldap.summary</source>
                 <target>Provides an LDAP client for PHP on top of PHP's ldap extension.</target>
             </trans-unit>
-            <trans-unit id="ldap.description">
-                <source>ldap.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="locale.summary">
                 <source>locale.summary</source>
                 <target>Provides fallback code to handle cases when the intl extension is missing. This component is deprecated since 2.3, use the Intl component instead.</target>
-            </trans-unit>
-            <trans-unit id="locale.description">
-                <source>locale.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="intl.summary">
                 <source>intl.summary</source>
                 <target>Provides fallback code to handle cases when the intl extension is missing.</target>
             </trans-unit>
-            <trans-unit id="intl.description">
-                <source>intl.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="icu.summary">
                 <source>icu.summary</source>
                 <target>Contains the data of the ICU library in a specific version. This component is deprecated since October 2014, use the Intl component instead.</target>
             </trans-unit>
-            <trans-unit id="icu.description">
-                <source>icu.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="optionsresolver.summary">
-                <source>optionsresolver.summary</source>
+            <trans-unit id="options-resolver.summary">
+                <source>options-resolver.summary</source>
                 <target>Helps you configuring objects with option arrays.</target>
-            </trans-unit>
-            <trans-unit id="optionsresolver.description">
-                <source>optionsresolver.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="process.summary">
                 <source>process.summary</source>
                 <target>Executes commands in sub-processes</target>
             </trans-unit>
-            <trans-unit id="process.description">
-                <source>process.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="propertyaccess.summary">
-                <source>propertyaccess.summary</source>
+            <trans-unit id="property-access.summary">
+                <source>property-access.summary</source>
                 <target>Provides function to read and write from/to an object or array using a simple string notation.</target>
             </trans-unit>
-            <trans-unit id="propertyaccess.description">
-                <source>propertyaccess.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="propertyinfo.summary">
-                <source>propertyinfo.summary</source>
+            <trans-unit id="property-info.summary">
+                <source>property-info.summary</source>
                 <target>Extracts information about the properties of PHP classes using metadata of popular sources (Doctrine, PHP Reflection, PHPdoc, etc.)</target>
-            </trans-unit>
-            <trans-unit id="propertyinfo.description">
-                <source>propertyinfo.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="routing.summary">
                 <source>routing.summary</source>
                 <target>Maps an HTTP request to a set of configuration variables.</target>
             </trans-unit>
-            <trans-unit id="routing.description">
-                <source>routing.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="security.summary">
                 <source>security.summary</source>
                 <target>Provides an infrastructure for sophisticated authorization systems.</target>
-            </trans-unit>
-            <trans-unit id="security.description">
-                <source>security.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="serializer.summary">
                 <source>serializer.summary</source>
                 <target>Turns objects into a specific format (XML, JSON, Yaml, ...) and the other way around.</target>
             </trans-unit>
-            <trans-unit id="serializer.description">
-                <source>serializer.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="stopwatch.summary">
                 <source>stopwatch.summary</source>
                 <target>Provides a way to profile code.</target>
-            </trans-unit>
-            <trans-unit id="stopwatch.description">
-                <source>stopwatch.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="templating.summary">
                 <source>templating.summary</source>
                 <target>Provides all the tools needed to build any kind of template system.</target>
             </trans-unit>
-            <trans-unit id="templating.description">
-                <source>templating.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="translation.summary">
                 <source>translation.summary</source>
                 <target>Provides tools to internationalize your application.</target>
-            </trans-unit>
-            <trans-unit id="translation.description">
-                <source>translation.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="validator.summary">
                 <source>validator.summary</source>
                 <target>Provides tools to validate classes.</target>
             </trans-unit>
-            <trans-unit id="validator.description">
-                <source>validator.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="vardumper.summary">
-                <source>vardumper.summary</source>
+            <trans-unit id="var-dumper.summary">
+                <source>var-dumper.summary</source>
                 <target>Provides mechanisms for walking through any arbitrary PHP variable. </target>
-            </trans-unit>
-            <trans-unit id="vardumper.description">
-                <source>vardumper.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="yaml.summary">
                 <source>yaml.summary</source>
                 <target>Loads and dumps YAML files.</target>
-            </trans-unit>
-            <trans-unit id="yaml.description">
-                <source>yaml.description</source>
-                <target />
             </trans-unit>
         </body>
     </file>

--- a/translations/component.fr.xliff
+++ b/translations/component.fr.xliff
@@ -52,279 +52,155 @@
                 <source>asset.summary</source>
                 <target>Prend en charge la génération d'URL et les versions des assets (ressources) telles que les feuilles de style CSS, les fichiers JavaScript et les images.</target>
             </trans-unit>
-            <trans-unit id="asset.description">
-                <source>asset.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="browserkit.summary">
-                <source>browserkit.summary</source>
+            <trans-unit id="browser-kit.summary">
+                <source>browser-kit.summary</source>
                 <target>Simule le comportement d'un navigateur web.</target>
             </trans-unit>
-            <trans-unit id="browserkit.description">
-                <source>browserkit.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="classloader.summary">
-                <source>classloader.summary</source>
+            <trans-unit id="class-loader.summary">
+                <source>class-loader.summary</source>
                 <target>Charge les classes de votre projet automatiquement si elles respectent les conventions standards de PHP.</target>
-            </trans-unit>
-            <trans-unit id="6">
-                <source>classloader.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="config.summary">
                 <source>config.summary</source>
                 <target>Aide à trouver, charger, combiner, auto-compléter et valider les valeurs de configuration.</target>
             </trans-unit>
-            <trans-unit id="config.description">
-                <source>config.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="console.summary">
                 <source>console.summary</source>
                 <target>Simplifie la création d'une interface en ligne de commande propre et testable.</target>
             </trans-unit>
-            <trans-unit id="console.description">
-                <source>console.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="cssselector.summary">
-                <source>cssselector.summary</source>
+            <trans-unit id="css-selector.summary">
+                <source>css-selector.summary</source>
                 <target>Convertit les sélecteurs CSS en expressions XPath.</target>
-            </trans-unit>
-            <trans-unit id="cssselector.description">
-                <source>cssselector.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="debug.summary">
                 <source>debug.summary</source>
                 <target>Fournit des outils complémentaires d'aide au débogage en PHP.</target>
             </trans-unit>
-            <trans-unit id="debug.description">
-                <source>debug.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="dependencyinjection.summary">
-                <source>dependencyinjection.summary</source>
+            <trans-unit id="dependency-injection.summary">
+                <source>dependency-injection.summary</source>
                 <target>Standardise et centralise la manière dont les objets sont construits dans une application.</target>
             </trans-unit>
-            <trans-unit id="dependencyinjection.description">
-                <source>dependencyinjection.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="domcrawler.summary">
-                <source>domcrawler.summary</source>
+            <trans-unit id="dom-crawler.summary">
+                <source>dom-crawler.summary</source>
                 <target>Simplifie la navigation dans le DOM pour des documents HTML et XML.</target>
             </trans-unit>
-            <trans-unit id="domcrawler.description">
-                <source>domcrawler.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="eventdispatcher.summary">
-                <source>eventdispatcher.summary</source>
+            <trans-unit id="event-dispatcher.summary">
+                <source>event-dispatcher.summary</source>
                 <target>Implémente le patron de conception Médiateur d'une manière simple et efficace pour rendre les projets PHP facilement extensibles.</target>
             </trans-unit>
-            <trans-unit id="eventdispatcher.description">
-                <source>eventdispatcher.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="expressionlanguage.summary">
-                <source>expressionlanguage.summary</source>
+            <trans-unit id="expression-language.summary">
+                <source>expression-language.summary</source>
                 <target>Fournit un moteur de compilation et d'évaluation d'expressions.</target>
-            </trans-unit>
-            <trans-unit id="expressionlanguage.description">
-                <source>expressionlanguage.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="filesystem.summary">
                 <source>filesystem.summary</source>
                 <target>Fournit des utilitaires basiques pour manipuler le système de fichiers.</target>
             </trans-unit>
-            <trans-unit id="filesystem.description">
-                <source>filesystem.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="finder.summary">
                 <source>finder.summary</source>
                 <target>Recherche des fichiers et dossiers grâce une interface fluide et intuitive.</target>
-            </trans-unit>
-            <trans-unit id="finder.description">
-                <source>finder.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="form.summary">
                 <source>form.summary</source>
                 <target>Fournit les outils pour concevoir, traiter et réutiliser des formulaires HTML.</target>
             </trans-unit>
-            <trans-unit id="form.description">
-                <source>form.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpfoundation.summary">
-                <source>httpfoundation.summary</source>
+            <trans-unit id="http-foundation.summary">
+                <source>http-foundation.summary</source>
                 <target>Définit une abstraction orientée objet pour la spécification du protocole HTTP.</target>
             </trans-unit>
-            <trans-unit id="httpfoundation.description">
-                <source>httpfoundation.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpkernel.summary">
-                <source>httpkernel.summary</source>
+            <trans-unit id="http-kernel.summary">
+                <source>http-kernel.summary</source>
                 <target>Fournit les briques de construction pour bâtir des frameworks HTTP souples et performants.</target>
-            </trans-unit>
-            <trans-unit id="httpkernel.description">
-                <source>httpkernel.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="locale.summary">
                 <source>locale.summary</source>
                 <target>Fournit une solution de remplacement de l'extension intl si elle est manquante sur le serveur. Ce composant est déprécié depuis la version 2.3, utilisez le composant Intl à la place.</target>
             </trans-unit>
-            <trans-unit id="locale.description">
-                <source>locale.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="intl.summary">
                 <source>intl.summary</source>
                 <target>Fournit une solution de remplacement de l'extension intl si elle est manquante sur le serveur.</target>
-            </trans-unit>
-            <trans-unit id="intl.description">
-                <source>intl.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="icu.summary">
                 <source>icu.summary</source>
                 <target>Contient les données de la librairie ICU dans une version spécifique. Ce composant est déprécié depuis Octobre 2014, utilisez le composant Intl à la place.</target>
             </trans-unit>
-            <trans-unit id="icu.description">
-                <source>icu.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="optionsresolver.summary">
-                <source>optionsresolver.summary</source>
+            <trans-unit id="options-resolver.summary">
+                <source>options-resolver.summary</source>
                 <target>Aide à configurer des objets avec des tableaux d'options.</target>
-            </trans-unit>
-            <trans-unit id="optionsresolver.description">
-                <source>optionsresolver.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="process.summary">
                 <source>process.summary</source>
                 <target>Éxecute des lignes de commande dans des sous-processus.</target>
             </trans-unit>
-            <trans-unit id="process.description">
-                <source>process.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="propertyaccess.summary">
-                <source>propertyaccess.summary</source>
+            <trans-unit id="property-access.summary">
+                <source>property-access.summary</source>
                 <target>Fournit des fonctions pour lire et écrire vers/depuis un objet ou un tableau utilisant une notation en chaînes de caractères.</target>
-            </trans-unit>
-            <trans-unit id="propertyaccess.description">
-                <source>propertyaccess.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="routing.summary">
                 <source>routing.summary</source>
                 <target>Associe une requête HTTP à un ensemble de variables de configuration.</target>
             </trans-unit>
-            <trans-unit id="routing.description">
-                <source>routing.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="security.summary">
                 <source>security.summary</source>
                 <target>Fournit une infrastructure pour concevoir des systèmes sophistiqués d'authentification et d'autorisation.</target>
-            </trans-unit>
-            <trans-unit id="security.description">
-                <source>security.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="serializer.summary">
                 <source>serializer.summary</source>
                 <target>Convertit les objets PHP dans un format spécifique (XML, JSON, Yaml, ...) et vice versa.</target>
             </trans-unit>
-            <trans-unit id="serializer.description">
-                <source>serializer.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="stopwatch.summary">
                 <source>stopwatch.summary</source>
                 <target>Fournit un moyen d'auditer et de chronométrer le code.</target>
-            </trans-unit>
-            <trans-unit id="stopwatch.description">
-                <source>stopwatch.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="templating.summary">
                 <source>templating.summary</source>
                 <target>Fournit les outils nécessaires pour concevoir des systèmes de rendu (templates).</target>
             </trans-unit>
-            <trans-unit id="templating.description">
-                <source>templating.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="translation.summary">
                 <source>translation.summary</source>
                 <target>Fournit les outils pour internationaliser des applications.</target>
-            </trans-unit>
-            <trans-unit id="translation.description">
-                <source>translation.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="validator.summary">
                 <source>validator.summary</source>
                 <target>Fournit les outils pour valider des classes, des objets et des données.</target>
             </trans-unit>
-            <trans-unit id="validator.description">
-                <source>validator.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="vardumper.summary">
-                <source>vardumper.summary</source>
+            <trans-unit id="var-dumper.summary">
+                <source>var-dumper.summary</source>
                 <target>Fournit des mécanismes pour étudier n'importe quelle variable PHP.</target>
-            </trans-unit>
-            <trans-unit id="vardumper.description">
-                <source>vardumper.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="yaml.summary">
                 <source>yaml.summary</source>
                 <target>Lit et écrit des fichiers au format YAML.</target>
-            </trans-unit>
-            <trans-unit id="yaml.description">
-                <source>yaml.description</source>
-                <target />
             </trans-unit>
         </body>
     </file>

--- a/translations/component.pl.xliff
+++ b/translations/component.pl.xliff
@@ -48,265 +48,149 @@
                 <target>Dokumentacja</target>
             </trans-unit>
 
-            <trans-unit id="browserkit.summary">
-                <source>browserkit.summary</source>
+            <trans-unit id="browser-kit.summary">
+                <source>browser-kit.summary</source>
                 <target>Symuluje zachowanie przeglądarki internetowej.</target>
             </trans-unit>
-            <trans-unit id="browserkit.description">
-                <source>browserkit.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="classloader.summary">
-                <source>classloader.summary</source>
+            <trans-unit id="class-loader.summary">
+                <source>class-loader.summary</source>
                 <target>Ładuje automatycznie klasy projektu jeśli stosują one standardowe konwencje PHP.</target>
-            </trans-unit>
-            <trans-unit id="6">
-                <source>classloader.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="config.summary">
                 <source>config.summary</source>
                 <target>Pomaga zlokalizować, wczytać, połączyć, wypełnić i walidować wartośći konfiguracyjne.</target>
             </trans-unit>
-            <trans-unit id="config.description">
-                <source>config.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="console.summary">
                 <source>console.summary</source>
                 <target>Ułatwia tworzenie pięknych i testowalnych interfejsów linii poleceń.</target>
             </trans-unit>
-            <trans-unit id="console.description">
-                <source>console.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="cssselector.summary">
-                <source>cssselector.summary</source>
+            <trans-unit id="css-selector.summary">
+                <source>css-selector.summary</source>
                 <target>Konwertuje selektory CSS na wyrażenia XPath.</target>
-            </trans-unit>
-            <trans-unit id="cssselector.description">
-                <source>cssselector.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="debug.summary">
                 <source>debug.summary</source>
                 <target>Dostarcza narzędzia do debugowania kodu PHP.</target>
             </trans-unit>
-            <trans-unit id="debug.description">
-                <source>debug.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="dependencyinjection.summary">
-                <source>dependencyinjection.summary</source>
+            <trans-unit id="dependency-injection.summary">
+                <source>dependency-injection.summary</source>
                 <target>Umożliwia standaryzację i centralizację sposobu konstruowania obiektów w Twojej aplikacji.</target>
             </trans-unit>
-            <trans-unit id="dependencyinjection.description">
-                <source>dependencyinjection.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="domcrawler.summary">
-                <source>domcrawler.summary</source>
+            <trans-unit id="dom-crawler.summary">
+                <source>dom-crawler.summary</source>
                 <target>Ułatwia nawigację DOM dla dokumentów HTML i XML.</target>
             </trans-unit>
-            <trans-unit id="domcrawler.description">
-                <source>domcrawler.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="eventdispatcher.summary">
-                <source>eventdispatcher.summary</source>
+            <trans-unit id="event-dispatcher.summary">
+                <source>event-dispatcher.summary</source>
                 <target>Implementuje uproszczoną wersję wzorca projektowego Obserwator.</target>
             </trans-unit>
-            <trans-unit id="eventdispatcher.description">
-                <source>eventdispatcher.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="expressionlanguage.summary">
-                <source>expressionlanguage.summary</source>
+            <trans-unit id="expression-language.summary">
+                <source>expression-language.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="expressionlanguage.description">
-                <source>expressionlanguage.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="filesystem.summary">
                 <source>filesystem.summary</source>
                 <target>Dostarcza podstawowe narzędzia dla systemu plików.</target>
             </trans-unit>
-            <trans-unit id="filesystem.description">
-                <source>filesystem.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="finder.summary">
                 <source>finder.summary</source>
                 <target>Znajduje pliki i katalogi poprzez intuicyiny interfejs.</target>
-            </trans-unit>
-            <trans-unit id="finder.description">
-                <source>finder.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="form.summary">
                 <source>form.summary</source>
                 <target></target>
             </trans-unit>
-            <trans-unit id="form.description">
-                <source>form.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpfoundation.summary">
-                <source>httpfoundation.summary</source>
+            <trans-unit id="http-foundation.summary">
+                <source>http-foundation.summary</source>
                 <target>Definiuje obiektowo zorientowaną warstwę dla specyfikacji HTTP.</target>
             </trans-unit>
-            <trans-unit id="httpfoundation.description">
-                <source>httpfoundation.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpkernel.summary">
-                <source>httpkernel.summary</source>
+            <trans-unit id="http-kernel.summary">
+                <source>http-kernel.summary</source>
                 <target>Dostarcza elementy konstrukcyjne do tworzenia elastycznych i szybkich frameworków opartych o HTTP.</target>
-            </trans-unit>
-            <trans-unit id="httpkernel.description">
-                <source>httpkernel.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="locale.summary">
                 <source>locale.summary</source>
                 <target>Dostarcza kod dla przypadków kiedy rozszerzenie intl nie jest dostępne.</target>
             </trans-unit>
-            <trans-unit id="locale.description">
-                <source>locale.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="intl.summary">
                 <source>intl.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="intl.description">
-                <source>intl.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="icu.summary">
                 <source>icu.summary</source>
                 <target></target>
             </trans-unit>
-            <trans-unit id="icu.description">
-                <source>icu.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="optionsresolver.summary">
-                <source>optionsresolver.summary</source>
+            <trans-unit id="options-resolver.summary">
+                <source>options-resolver.summary</source>
                 <target>Pomaga w konfiguracji obiektów przy użyciu tablic opcji.</target>
-            </trans-unit>
-            <trans-unit id="optionsresolver.description">
-                <source>optionsresolver.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="process.summary">
                 <source>process.summary</source>
                 <target>Wykonuje polecenia w podprocesach.</target>
             </trans-unit>
-            <trans-unit id="process.description">
-                <source>process.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="propertyaccess.summary">
-                <source>propertyaccess.summary</source>
+            <trans-unit id="property-access.summary">
+                <source>property-access.summary</source>
                 <target>Dostarcza funkcjonalność odczytu oraz zapisu z/do obiektu lub tablicy przy użyciu prostej notacji znakowej.</target>
-            </trans-unit>
-            <trans-unit id="propertyaccess.description">
-                <source>propertyaccess.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="routing.summary">
                 <source>routing.summary</source>
                 <target>Mapuje żądanie HTTP na zestaw zmiennych konfiguracyjnych.</target>
             </trans-unit>
-            <trans-unit id="routing.description">
-                <source>routing.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="security.summary">
                 <source>security.summary</source>
                 <target>Dostarcza infrastrukturę dla złożonych systemów uwierzytelniania</target>
-            </trans-unit>
-            <trans-unit id="security.description">
-                <source>security.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="serializer.summary">
                 <source>serializer.summary</source>
                 <target>Przekształca obiekty do wybranego formatu (XML, JSON, Yaml, ...) i odwrotnie.</target>
             </trans-unit>
-            <trans-unit id="serializer.description">
-                <source>serializer.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="stopwatch.summary">
                 <source>stopwatch.summary</source>
                 <target>Komponent Stopwatch dostarcza mechanizmy profilowania kodu.</target>
-            </trans-unit>
-            <trans-unit id="stopwatch.description">
-                <source>stopwatch.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="templating.summary">
                 <source>templating.summary</source>
                 <target>Dostarcza wszystkie narzędzia niezbędne do budowy dowolnego rodzaju systemu szablonów.</target>
             </trans-unit>
-            <trans-unit id="templating.description">
-                <source>templating.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="translation.summary">
                 <source>translation.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="translation.description">
-                <source>translation.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="validator.summary">
                 <source>validator.summary</source>
                 <target></target>
             </trans-unit>
-            <trans-unit id="validator.description">
-                <source>validator.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="yaml.summary">
                 <source>yaml.summary</source>
                 <target>Wczytuje i eksportuje do plików YAML.</target>
-            </trans-unit>
-            <trans-unit id="yaml.description">
-                <source>yaml.description</source>
-                <target />
             </trans-unit>
         </body>
     </file>

--- a/translations/component.pt.xliff
+++ b/translations/component.pt.xliff
@@ -48,265 +48,149 @@
                 <target>Documentação</target>
             </trans-unit>
 
-            <trans-unit id="browserkit.summary">
-                <source>browserkit.summary</source>
+            <trans-unit id="browser-kit.summary">
+                <source>browser-kit.summary</source>
                 <target>Simula o funcionamento de um navegador web.</target>
             </trans-unit>
-            <trans-unit id="browserkit.description">
-                <source>browserkit.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="classloader.summary">
-                <source>classloader.summary</source>
+            <trans-unit id="class-loader.summary">
+                <source>class-loader.summary</source>
                 <target>Carrega as classes do seu projeto automaticamente se elas seguirem as convenções padrão do PHP.</target>
-            </trans-unit>
-            <trans-unit id="6">
-                <source>classloader.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="config.summary">
                 <source>config.summary</source>
                 <target>Ajuda-o a encontrar, carregar, combinar, autopreencher e validar os valores de configuração.</target>
             </trans-unit>
-            <trans-unit id="config.description">
-                <source>config.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="console.summary">
                 <source>console.summary</source>
                 <target>Facilita a criação de interfaces bonitas e testáveis para a linha de comandos.</target>
             </trans-unit>
-            <trans-unit id="console.description">
-                <source>console.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="cssselector.summary">
-                <source>cssselector.summary</source>
+            <trans-unit id="css-selector.summary">
+                <source>css-selector.summary</source>
                 <target>Converte os seletores CSS para expressões XPath.</target>
-            </trans-unit>
-            <trans-unit id="cssselector.description">
-                <source>cssselector.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="debug.summary">
                 <source>debug.summary</source>
                 <target>Fornece ferramentas para facilitar o debugging de código PHP.</target>
             </trans-unit>
-            <trans-unit id="debug.description">
-                <source>debug.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="dependencyinjection.summary">
-                <source>dependencyinjection.summary</source>
+            <trans-unit id="dependency-injection.summary">
+                <source>dependency-injection.summary</source>
                 <target>Permite que você padronize e centralize a forma como os objetos são construídos na sua aplicação.</target>
             </trans-unit>
-            <trans-unit id="dependencyinjection.description">
-                <source>dependencyinjection.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="domcrawler.summary">
-                <source>domcrawler.summary</source>
+            <trans-unit id="dom-crawler.summary">
+                <source>dom-crawler.summary</source>
                 <target>Facilita a navegação do DOM nos documentos HTML e XML.</target>
             </trans-unit>
-            <trans-unit id="domcrawler.description">
-                <source>domcrawler.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="eventdispatcher.summary">
-                <source>eventdispatcher.summary</source>
+            <trans-unit id="event-dispatcher.summary">
+                <source>event-dispatcher.summary</source>
                 <target>Implementa uma versão leve do padrão de desenho "Observer".</target>
             </trans-unit>
-            <trans-unit id="eventdispatcher.description">
-                <source>eventdispatcher.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="expressionlanguage.summary">
-                <source>expressionlanguage.summary</source>
+            <trans-unit id="expression-language.summary">
+                <source>expression-language.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="expressionlanguage.description">
-                <source>expressionlanguage.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="filesystem.summary">
                 <source>filesystem.summary</source>
                 <target>Fornece funcionalidades básicas para o sistema de ficheiros.</target>
             </trans-unit>
-            <trans-unit id="filesystem.description">
-                <source>filesystem.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="finder.summary">
                 <source>finder.summary</source>
                 <target>Procura ficheiros e diretorias através de um interface intuítivo e fluente.</target>
-            </trans-unit>
-            <trans-unit id="finder.description">
-                <source>finder.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="form.summary">
                 <source>form.summary</source>
                 <target>Fornece ferramentas para a definição de formulários, renderização e faz o mapeamento dos pedidos de dados com o modelo relacionado.</target>
             </trans-unit>
-            <trans-unit id="form.description">
-                <source>form.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpfoundation.summary">
-                <source>httpfoundation.summary</source>
+            <trans-unit id="http-foundation.summary">
+                <source>http-foundation.summary</source>
                 <target>Define uma camada orientada a objeto para a especificação HTTP.</target>
             </trans-unit>
-            <trans-unit id="httpfoundation.description">
-                <source>httpfoundation.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpkernel.summary">
-                <source>httpkernel.summary</source>
+            <trans-unit id="http-kernel.summary">
+                <source>http-kernel.summary</source>
                 <target>Fornece os blocos de construção para criar frameworks flexíveis e rápidas baseadas em HTTP.</target>
-            </trans-unit>
-            <trans-unit id="httpkernel.description">
-                <source>httpkernel.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="locale.summary">
                 <source>locale.summary</source>
                 <target>Fornece código de retorno para os casos em que a extensão de intl está em falta.</target>
             </trans-unit>
-            <trans-unit id="locale.description">
-                <source>locale.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="intl.summary">
                 <source>intl.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="intl.description">
-                <source>intl.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="icu.summary">
                 <source>icu.summary</source>
                 <target></target>
             </trans-unit>
-            <trans-unit id="icu.description">
-                <source>icu.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="optionsresolver.summary">
-                <source>optionsresolver.summary</source>
+            <trans-unit id="options-resolver.summary">
+                <source>options-resolver.summary</source>
                 <target>Ajuda na configuração de objetos com opções de matrizes.</target>
-            </trans-unit>
-            <trans-unit id="optionsresolver.description">
-                <source>optionsresolver.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="process.summary">
                 <source>process.summary</source>
                 <target>Executa comandos em sub-processos.</target>
             </trans-unit>
-            <trans-unit id="process.description">
-                <source>process.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="propertyaccess.summary">
-                <source>propertyaccess.summary</source>
+            <trans-unit id="property-access.summary">
+                <source>property-access.summary</source>
                 <target>Fornece funcionalidades para ler e escrever de e para um objecto ou matriz usando uma anotação de texto simples.</target>
-            </trans-unit>
-            <trans-unit id="propertyaccess.description">
-                <source>propertyaccess.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="routing.summary">
                 <source>routing.summary</source>
                 <target>Mapea um pedido HTTP para um conjunto de variáveis configuráveis.</target>
             </trans-unit>
-            <trans-unit id="routing.description">
-                <source>routing.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="security.summary">
                 <source>security.summary</source>
                 <target>Fornece uma infraestrutura sofisticada para autenticação de sistemas.</target>
-            </trans-unit>
-            <trans-unit id="security.description">
-                <source>security.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="serializer.summary">
                 <source>serializer.summary</source>
                 <target>Transforma objetos em formatos específicos (XML, JSON, Yaml, ...) e vice-versa.</target>
             </trans-unit>
-            <trans-unit id="serializer.description">
-                <source>serializer.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="stopwatch.summary">
                 <source>stopwatch.summary</source>
                 <target>Fornece uma forma de fazer profile do código.</target>
-            </trans-unit>
-            <trans-unit id="stopwatch.description">
-                <source>stopwatch.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="templating.summary">
                 <source>templating.summary</source>
                 <target>Fornece todas as ferramentas necessárias para construir qualquer tipo de sistemas de templates.</target>
             </trans-unit>
-            <trans-unit id="templating.description">
-                <source>templating.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="translation.summary">
                 <source>translation.summary</source>
                 <target>Fornece ferramentas para carregar ficheiros de tradução e traduz texto incluíndo suporte para a pluralização.</target>
-            </trans-unit>
-            <trans-unit id="translation.description">
-                <source>translation.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="validator.summary">
                 <source>validator.summary</source>
                 <target>Baseado na especificação de validação Bean JSR-303, permite especificar regras de validação para classe usando XML, YAML, PHP ou anotações.</target>
             </trans-unit>
-            <trans-unit id="validator.description">
-                <source>validator.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="yaml.summary">
                 <source>yaml.summary</source>
                 <target>Carrega e faz output de ficheiros YAML.</target>
-            </trans-unit>
-            <trans-unit id="yaml.description">
-                <source>yaml.description</source>
-                <target />
             </trans-unit>
         </body>
     </file>

--- a/translations/component.pt_BR.xliff
+++ b/translations/component.pt_BR.xliff
@@ -48,265 +48,149 @@
                 <target>Documentação</target>
             </trans-unit>
 
-            <trans-unit id="browserkit.summary">
-                <source>browserkit.summary</source>
+            <trans-unit id="browser-kit.summary">
+                <source>browser-kit.summary</source>
                 <target>Simula o funcionamento de um navegador web.</target>
             </trans-unit>
-            <trans-unit id="browserkit.description">
-                <source>browserkit.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="classloader.summary">
-                <source>classloader.summary</source>
+            <trans-unit id="class-loader.summary">
+                <source>class-loader.summary</source>
                 <target>Carrega as classes do seu projeto automaticamente se elas seguirem as convenções padrão do PHP.</target>
-            </trans-unit>
-            <trans-unit id="6">
-                <source>classloader.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="config.summary">
                 <source>config.summary</source>
                 <target>Ajuda a encontrar, carregar, combinar, autopreencher e validar os valores de configuração.</target>
             </trans-unit>
-            <trans-unit id="config.description">
-                <source>config.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="console.summary">
                 <source>console.summary</source>
                 <target>Facilita a criação de interfaces bonitas e testáveis para a linha de comando.</target>
             </trans-unit>
-            <trans-unit id="console.description">
-                <source>console.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="cssselector.summary">
-                <source>cssselector.summary</source>
+            <trans-unit id="css-selector.summary">
+                <source>css-selector.summary</source>
                 <target>Converte os seletores CSS para expressões XPath.</target>
-            </trans-unit>
-            <trans-unit id="cssselector.description">
-                <source>cssselector.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="debug.summary">
                 <source>debug.summary</source>
                 <target>Fornece ferramentas para facilitar o debugging de código PHP.</target>
             </trans-unit>
-            <trans-unit id="debug.description">
-                <source>debug.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="dependencyinjection.summary">
-                <source>dependencyinjection.summary</source>
+            <trans-unit id="dependency-injection.summary">
+                <source>dependency-injection.summary</source>
                 <target>Permite que você padronize e centralize a forma como os objetos são construídos na sua aplicação.</target>
             </trans-unit>
-            <trans-unit id="dependencyinjection.description">
-                <source>dependencyinjection.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="domcrawler.summary">
-                <source>domcrawler.summary</source>
+            <trans-unit id="dom-crawler.summary">
+                <source>dom-crawler.summary</source>
                 <target>Facilita a navegação do DOM nos documentos HTML e XML.</target>
             </trans-unit>
-            <trans-unit id="domcrawler.description">
-                <source>domcrawler.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="eventdispatcher.summary">
-                <source>eventdispatcher.summary</source>
+            <trans-unit id="event-dispatcher.summary">
+                <source>event-dispatcher.summary</source>
                 <target>Implementa uma versão leve do padrão de projeto "Observer".</target>
             </trans-unit>
-            <trans-unit id="eventdispatcher.description">
-                <source>eventdispatcher.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="expressionlanguage.summary">
-                <source>expressionlanguage.summary</source>
+            <trans-unit id="expression-language.summary">
+                <source>expression-language.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="expressionlanguage.description">
-                <source>expressionlanguage.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="filesystem.summary">
                 <source>filesystem.summary</source>
                 <target>Fornece funcionalidades básicas para o sistema de arquivos.</target>
             </trans-unit>
-            <trans-unit id="filesystem.description">
-                <source>filesystem.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="finder.summary">
                 <source>finder.summary</source>
                 <target>Procura arquivos e diretórios através de uma interface intuitiva e fluente.</target>
-            </trans-unit>
-            <trans-unit id="finder.description">
-                <source>finder.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="form.summary">
                 <source>form.summary</source>
                 <target>Fornece ferramentas para a definição de formulários, renderização e faz o mapeamento dos pedidos de dados com o modelo relacionado.</target>
             </trans-unit>
-            <trans-unit id="form.description">
-                <source>form.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpfoundation.summary">
-                <source>httpfoundation.summary</source>
+            <trans-unit id="http-foundation.summary">
+                <source>http-foundation.summary</source>
                 <target>Define uma camada orientada a objeto para a especificação HTTP.</target>
             </trans-unit>
-            <trans-unit id="httpfoundation.description">
-                <source>httpfoundation.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpkernel.summary">
-                <source>httpkernel.summary</source>
+            <trans-unit id="http-kernel.summary">
+                <source>http-kernel.summary</source>
                 <target>Fornece blocos de construção para criar frameworks flexíveis e rápidos com base no HTTP.</target>
-            </trans-unit>
-            <trans-unit id="httpkernel.description">
-                <source>httpkernel.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="locale.summary">
                 <source>locale.summary</source>
                 <target>Fornece código de contingência para os casos em que a extensão intl não está disponível.</target>
             </trans-unit>
-            <trans-unit id="locale.description">
-                <source>locale.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="intl.summary">
                 <source>intl.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="intl.description">
-                <source>intl.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="icu.summary">
                 <source>icu.summary</source>
                 <target></target>
             </trans-unit>
-            <trans-unit id="icu.description">
-                <source>icu.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="optionsresolver.summary">
-                <source>optionsresolver.summary</source>
+            <trans-unit id="options-resolver.summary">
+                <source>options-resolver.summary</source>
                 <target>Ajuda na configuração de objetos com opções de arrays.</target>
-            </trans-unit>
-            <trans-unit id="optionsresolver.description">
-                <source>optionsresolver.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="process.summary">
                 <source>process.summary</source>
                 <target>Executa comandos em sub-processos.</target>
             </trans-unit>
-            <trans-unit id="process.description">
-                <source>process.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="propertyaccess.summary">
-                <source>propertyaccess.summary</source>
+            <trans-unit id="property-access.summary">
+                <source>property-access.summary</source>
                 <target>Fornece funcionalidades para ler e escrever de e para um objeto ou array usando uma notação de string simples.</target>
-            </trans-unit>
-            <trans-unit id="propertyaccess.description">
-                <source>propertyaccess.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="routing.summary">
                 <source>routing.summary</source>
                 <target>Mapeia um pedido HTTP para um conjunto de variáveis configuráveis.</target>
             </trans-unit>
-            <trans-unit id="routing.description">
-                <source>routing.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="security.summary">
                 <source>security.summary</source>
                 <target>Fornece uma infraestrutura sofisticada para autenticação de sistemas.</target>
-            </trans-unit>
-            <trans-unit id="security.description">
-                <source>security.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="serializer.summary">
                 <source>serializer.summary</source>
                 <target>Transforma objetos em formatos específicos (XML, JSON, Yaml, ...) e vice-versa.</target>
             </trans-unit>
-            <trans-unit id="serializer.description">
-                <source>serializer.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="stopwatch.summary">
                 <source>stopwatch.summary</source>
                 <target>Fornece uma forma de fazer profile do código.</target>
-            </trans-unit>
-            <trans-unit id="stopwatch.description">
-                <source>stopwatch.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="templating.summary">
                 <source>templating.summary</source>
                 <target>Fornece todas as ferramentas necessárias para construir qualquer tipo de sistema de templates.</target>
             </trans-unit>
-            <trans-unit id="templating.description">
-                <source>templating.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="translation.summary">
                 <source>translation.summary</source>
                 <target>Fornece ferramentas para carregar arquivos de tradução e traduz o texto incluíndo suporte para a pluralização.</target>
-            </trans-unit>
-            <trans-unit id="translation.description">
-                <source>translation.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="validator.summary">
                 <source>validator.summary</source>
                 <target>Com base na especificação de validação Bean JSR-303, permite especificar regras de validação para classe usando XML, YAML, PHP ou anotações.</target>
             </trans-unit>
-            <trans-unit id="validator.description">
-                <source>validator.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="yaml.summary">
                 <source>yaml.summary</source>
                 <target>Carrega e faz output de arquivos YAML.</target>
-            </trans-unit>
-            <trans-unit id="yaml.description">
-                <source>yaml.description</source>
-                <target />
             </trans-unit>
         </body>
     </file>

--- a/translations/component.ru.xliff
+++ b/translations/component.ru.xliff
@@ -3,7 +3,7 @@
     <file source-language="ru" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>browserkit.summary</source>
+                <source>browser-kit.summary</source>
                 <target>
                     BrowserKit имитирует работу веб-браузера.
                 </target>
@@ -27,7 +27,7 @@
                </target>
             </trans-unit>
             <trans-unit id="5">
-               <source>classloader.summary</source>
+               <source>class-loader.summary</source>
                <target>
                     Автоматически загружает классы вашего проекта, если они следуют некоторым стандартным соглашениям PHP.
                </target>
@@ -51,7 +51,7 @@
                </target>
             </trans-unit>
             <trans-unit id="9">
-               <source>cssselector.summary</source>
+               <source>css-selector.summary</source>
                <target>
                    Превращает CSS селекторы в выражения XPath.
                </target>
@@ -75,7 +75,7 @@
                </target>
             </trans-unit>
             <trans-unit id="13">
-               <source>dependencyinjection.summary</source>
+               <source>dependency-injection.summary</source>
                <target>
                    Позволяет стандартизировать и централизовать способы создания объектов в вашем приложении.
                </target>
@@ -87,7 +87,7 @@
                </target>
             </trans-unit>
             <trans-unit id="15">
-               <source>domcrawler.summary</source>
+               <source>dom-crawler.summary</source>
                <target>
                    Облегчает навигацию по DOM для HTML и XML документов.
                </target>
@@ -99,7 +99,7 @@
                </target>
             </trans-unit>
             <trans-unit id="17">
-               <source>eventdispatcher.summary</source>
+               <source>event-dispatcher.summary</source>
                <target>
                    Реализует облегченную версию шаблона проектирования Observer.
                </target>
@@ -135,7 +135,7 @@
                </target>
             </trans-unit>
             <trans-unit id="23">
-               <source>httpfoundation.summary</source>
+               <source>http-foundation.summary</source>
                <target>
                    Определяет объектно-ориентированный слой для спецификации HTTP.
                </target>
@@ -147,7 +147,7 @@
                </target>
             </trans-unit>
             <trans-unit id="25">
-               <source>httpkernel.summary</source>
+               <source>http-kernel.summary</source>
                <target>
                    Предоставляет строительные блоки для создания быстрых и гибких фреймворков, работающих на базе стандарта HTTP.
                </target>
@@ -183,7 +183,7 @@
                </target>
             </trans-unit>
             <trans-unit id="31">
-               <source>optionsresolver.summary</source>
+               <source>options-resolver.summary</source>
                <target>
                   Помогает с конфигурированием объектов с option arrays.
                </target>
@@ -207,7 +207,7 @@
                </target>
             </trans-unit>
             <trans-unit id="35">
-               <source>propertyaccess.summary</source>
+               <source>property-access.summary</source>
                <target>
                   Предоставляет функции для чтения из / записи в объект или массив с использованием строковой нотации.
                </target>

--- a/translations/component.sk.xliff
+++ b/translations/component.sk.xliff
@@ -48,265 +48,149 @@
                 <target>Dokumentácia</target>
             </trans-unit>
 
-            <trans-unit id="browserkit.summary">
-                <source>browserkit.summary</source>
+            <trans-unit id="browser-kit.summary">
+                <source>browser-kit.summary</source>
                 <target>Simuluje chovanie webového prehliadača.</target>
             </trans-unit>
-            <trans-unit id="browserkit.description">
-                <source>browserkit.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="classloader.summary">
-                <source>classloader.summary</source>
+            <trans-unit id="class-loader.summary">
+                <source>class-loader.summary</source>
                 <target>Automaticky načítava súbory s triedami, ak tieto dodržujú niektoré štandardé PHP konvencie.</target>
-            </trans-unit>
-            <trans-unit id="6">
-                <source>classloader.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="config.summary">
                 <source>config.summary</source>
                 <target>Pomáha vyhľadať, načítať, kombinovať, automaticky vyplniť a kontrolovať konfiguráciu.</target>
             </trans-unit>
-            <trans-unit id="config.description">
-                <source>config.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="console.summary">
                 <source>console.summary</source>
                 <target>Uľahčuje vytváranie krásnych a testovateľných aplikácií pre príkazový riadok.</target>
             </trans-unit>
-            <trans-unit id="console.description">
-                <source>console.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="cssselector.summary">
-                <source>cssselector.summary</source>
+            <trans-unit id="css-selector.summary">
+                <source>css-selector.summary</source>
                 <target>Konveruje CSS selektory na XPath výrazy.</target>
-            </trans-unit>
-            <trans-unit id="cssselector.description">
-                <source>cssselector.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="debug.summary">
                 <source>debug.summary</source>
                 <target>Ponúka nástroje pre jednoduchšie testovanie PHP kódu.</target>
             </trans-unit>
-            <trans-unit id="debug.description">
-                <source>debug.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="dependencyinjection.summary">
-                <source>dependencyinjection.summary</source>
+            <trans-unit id="dependency-injection.summary">
+                <source>dependency-injection.summary</source>
                 <target>Umožnuje štandardizovať a centralizovať spôsob akým sú objekty tvorené vo Vašej aplikácií.</target>
             </trans-unit>
-            <trans-unit id="dependencyinjection.description">
-                <source>dependencyinjection.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="domcrawler.summary">
-                <source>domcrawler.summary</source>
+            <trans-unit id="dom-crawler.summary">
+                <source>dom-crawler.summary</source>
                 <target>Uľahčuje prechádzanie DOM štruktúry pre HTML a XML dokumenty.</target>
             </trans-unit>
-            <trans-unit id="domcrawler.description">
-                <source>domcrawler.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="eventdispatcher.summary">
-                <source>eventdispatcher.summary</source>
+            <trans-unit id="event-dispatcher.summary">
+                <source>event-dispatcher.summary</source>
                 <target>Implementuje odľahčenú verziu návrhového vzoru Observer.</target>
             </trans-unit>
-            <trans-unit id="eventdispatcher.description">
-                <source>eventdispatcher.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="expressionlanguage.summary">
-                <source>expressionlanguage.summary</source>
+            <trans-unit id="expression-language.summary">
+                <source>expression-language.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="expressionlanguage.description">
-                <source>expressionlanguage.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="filesystem.summary">
                 <source>filesystem.summary</source>
                 <target>Poskytuje základné nástroj pre prácu so súbormi a adresármi.</target>
             </trans-unit>
-            <trans-unit id="filesystem.description">
-                <source>filesystem.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="finder.summary">
                 <source>finder.summary</source>
                 <target>Vyhľadáva súbory a adresáre pomocou prehľadného zápisu.</target>
-            </trans-unit>
-            <trans-unit id="finder.description">
-                <source>finder.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="form.summary">
                 <source>form.summary</source>
                 <target></target>
             </trans-unit>
-            <trans-unit id="form.description">
-                <source>form.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpfoundation.summary">
-                <source>httpfoundation.summary</source>
+            <trans-unit id="http-foundation.summary">
+                <source>http-foundation.summary</source>
                 <target>Objektovo orientovaná vrstva pre prácu s protokolom HTTP.</target>
             </trans-unit>
-            <trans-unit id="httpfoundation.description">
-                <source>httpfoundation.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpkernel.summary">
-                <source>httpkernel.summary</source>
+            <trans-unit id="http-kernel.summary">
+                <source>http-kernel.summary</source>
                 <target>Poskytuje základné stavebné prvky pre vytvorenie flexibilného a rýchleho frameworku založeného na protokole HTTP.</target>
-            </trans-unit>
-            <trans-unit id="httpkernel.description">
-                <source>httpkernel.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="locale.summary">
                 <source>locale.summary</source>
                 <target>Poskytuje rezervný kod v prípadoch kedy nie je dostupne PHP rozšírenie intl.</target>
             </trans-unit>
-            <trans-unit id="locale.description">
-                <source>locale.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="intl.summary">
                 <source>intl.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="intl.description">
-                <source>intl.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="icu.summary">
                 <source>icu.summary</source>
                 <target></target>
             </trans-unit>
-            <trans-unit id="icu.description">
-                <source>icu.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="optionsresolver.summary">
-                <source>optionsresolver.summary</source>
+            <trans-unit id="options-resolver.summary">
+                <source>options-resolver.summary</source>
                 <target>Pomáha konfigurovať objekty pomocou jednoduchého poľa.</target>
-            </trans-unit>
-            <trans-unit id="optionsresolver.description">
-                <source>optionsresolver.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="process.summary">
                 <source>process.summary</source>
                 <target>Spúšta príkazy v sub-procesoch.</target>
             </trans-unit>
-            <trans-unit id="process.description">
-                <source>process.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="propertyaccess.summary">
-                <source>propertyaccess.summary</source>
+            <trans-unit id="property-access.summary">
+                <source>property-access.summary</source>
                 <target>Poskytuje funkcie pre čítanie a zápis z/do objektu a poľa pomocou jednoduchého textového zápisu.</target>
-            </trans-unit>
-            <trans-unit id="propertyaccess.description">
-                <source>propertyaccess.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="routing.summary">
                 <source>routing.summary</source>
                 <target>Mapuje HTTP požiadavky na sadu konfiguračných premenných.</target>
             </trans-unit>
-            <trans-unit id="routing.description">
-                <source>routing.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="security.summary">
                 <source>security.summary</source>
                 <target>Poskytuje sofistikované autorizačné mechanizmy.</target>
-            </trans-unit>
-            <trans-unit id="security.description">
-                <source>security.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="serializer.summary">
                 <source>serializer.summary</source>
                 <target>Konvertuje objekty do rôznych formátov (XML, JSON, Yaml, ...) a naopak.</target>
             </trans-unit>
-            <trans-unit id="serializer.description">
-                <source>serializer.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="stopwatch.summary">
                 <source>stopwatch.summary</source>
                 <target>Umožnuje profilovať kód.</target>
-            </trans-unit>
-            <trans-unit id="stopwatch.description">
-                <source>stopwatch.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="templating.summary">
                 <source>templating.summary</source>
                 <target>Poskytuje všetky nástroje potrebné pre pripojenie akéhokoľvek šablónovacieho systému.</target>
             </trans-unit>
-            <trans-unit id="templating.description">
-                <source>templating.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="translation.summary">
                 <source>translation.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="translation.description">
-                <source>translation.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="validator.summary">
                 <source>validator.summary</source>
                 <target></target>
             </trans-unit>
-            <trans-unit id="validator.description">
-                <source>validator.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="yaml.summary">
                 <source>yaml.summary</source>
                 <target>Číta a zapisuje do YAML súborov.</target>
-            </trans-unit>
-            <trans-unit id="yaml.description">
-                <source>yaml.description</source>
-                <target />
             </trans-unit>
         </body>
     </file>

--- a/translations/component.sl.xliff
+++ b/translations/component.sl.xliff
@@ -52,306 +52,170 @@
                 <source>asset.summary</source>
                 <target>Upravlja generiranje URL-jev in različice spletnih sredstev, kot so CSS stili,datoteke JavSscrip in datoteke slik.</target>
             </trans-unit>
-            <trans-unit id="asset.description">
-                <source>asset.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="browserkit.summary">
-                <source>browserkit.summary</source>
+            <trans-unit id="browser-kit.summary">
+                <source>browser-kit.summary</source>
                 <target>Simulira delovanje spletnega brskalnika.</target>
             </trans-unit>
-            <trans-unit id="browserkit.description">
-                <source>browserkit.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="classloader.summary">
-                <source>classloader.summary</source>
+            <trans-unit id="class-loader.summary">
+                <source>class-loader.summary</source>
                 <target>Avtomatsko naloži projektne razrede, če sledijo standardnim PHP konvencijam.</target>
-            </trans-unit>
-            <trans-unit id="6">
-                <source>classloader.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="config.summary">
                 <source>config.summary</source>
                 <target>Pomaga najti, naložiti, združiti, samodejno izpolniti in potrditi nastavitvene vrednosti.</target>
             </trans-unit>
-            <trans-unit id="config.description">
-                <source>config.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="console.summary">
                 <source>console.summary</source>
                 <target>Poenostavi ustvarjanje lepih in testnih vmesnikov ukazne vrstice.</target>
             </trans-unit>
-            <trans-unit id="console.description">
-                <source>console.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="cssselector.summary">
-                <source>cssselector.summary</source>
+            <trans-unit id="css-selector.summary">
+                <source>css-selector.summary</source>
                 <target>Pretvori izbirnike CSS v izraze XPath.</target>
-            </trans-unit>
-            <trans-unit id="cssselector.description">
-                <source>cssselector.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="debug.summary">
                 <source>debug.summary</source>
                 <target>Ponuja orodja za enostavnejše razhroščevanje PHP kode.</target>
             </trans-unit>
-            <trans-unit id="debug.description">
-                <source>debug.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="dependencyinjection.summary">
-                <source>dependencyinjection.summary</source>
+            <trans-unit id="dependency-injection.summary">
+                <source>dependency-injection.summary</source>
                 <target>Omogoča standardizacijo in centralizacijo načina konstrukcije objektov v vaši aplikaciji.</target>
             </trans-unit>
-            <trans-unit id="dependencyinjection.description">
-                <source>dependencyinjection.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="domcrawler.summary">
-                <source>domcrawler.summary</source>
+            <trans-unit id="dom-crawler.summary">
+                <source>dom-crawler.summary</source>
                 <target>Poenostavi navigacijo DOM za HTML in XML dokumente.</target>
             </trans-unit>
-            <trans-unit id="domcrawler.description">
-                <source>domcrawler.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="eventdispatcher.summary">
-                <source>eventdispatcher.summary</source>
+            <trans-unit id="event-dispatcher.summary">
+                <source>event-dispatcher.summary</source>
                 <target>Implementira mediator vzorec na enostaven in efektiven način, da naredi projekte resnično razširljive.</target>
             </trans-unit>
-            <trans-unit id="eventdispatcher.description">
-                <source>eventdispatcher.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="expressionlanguage.summary">
-                <source>expressionlanguage.summary</source>
+            <trans-unit id="expression-language.summary">
+                <source>expression-language.summary</source>
                 <target>Ponuja motor, ki lahko prevede in oceni izraze.</target>
-            </trans-unit>
-            <trans-unit id="expressionlanguage.description">
-                <source>expressionlanguage.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="filesystem.summary">
                 <source>filesystem.summary</source>
                 <target>Ponuja osnovno podporo za datotečni sistem.</target>
             </trans-unit>
-            <trans-unit id="filesystem.description">
-                <source>filesystem.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="finder.summary">
                 <source>finder.summary</source>
                 <target>Najde datoteke in direktorije preko intuitivno tekočega vmesnika.</target>
-            </trans-unit>
-            <trans-unit id="finder.description">
-                <source>finder.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="form.summary">
                 <source>form.summary</source>
                 <target>Ponuja orodja za enostavno izdelavo, procesiranje in ponovno uporabo HTML obrazcev.</target>
             </trans-unit>
-            <trans-unit id="form.description">
-                <source>form.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="guard.summary">
                 <source>guard.summary</source>
                 <target>Združi mnoge nivoje preverjanja pristnosti in zelo poenostavi izdelavo kompleksnih sistemov preverjanja pristnosti, kjer imate polno kontrolo.</target>
             </trans-unit>
-            <trans-unit id="guard.description">
-                <source>guard.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpfoundation.summary">
-                <source>httpfoundation.summary</source>
+            <trans-unit id="http-foundation.summary">
+                <source>http-foundation.summary</source>
                 <target>Opredeljuje objektno orientirano plast za specifikacijo HTTP.</target>
             </trans-unit>
-            <trans-unit id="httpfoundation.description">
-                <source>httpfoundation.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpkernel.summary">
-                <source>httpkernel.summary</source>
+            <trans-unit id="http-kernel.summary">
+                <source>http-kernel.summary</source>
                 <target>Zagotavlja gradnike za izdelavo fleksibilnega in hitrih ogrodij na osnovi HTTP.</target>
-            </trans-unit>
-            <trans-unit id="httpkernel.description">
-                <source>httpkernel.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="ldap.summary">
                 <source>ldap.summary</source>
                 <target>Ponuja klienta LDAP za PHP na vrhu PHP razširitve ldap.</target>
             </trans-unit>
-            <trans-unit id="ldap.description">
-                <source>ldap.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="locale.summary">
                 <source>locale.summary</source>
                 <target>Zagotavlja nadomestno kodo za upravljanje primerov, kjer manjka razširitev intl. Ta komponenta je opuščena od 2.3 in namesto nje je v uporabi Intl komponenta.</target>
-            </trans-unit>
-            <trans-unit id="locale.description">
-                <source>locale.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="intl.summary">
                 <source>intl.summary</source>
                 <target>Ponuja nadomestno kodo za upravljanje primerov, kjer manjka razširitev intl.</target>
             </trans-unit>
-            <trans-unit id="intl.description">
-                <source>intl.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="icu.summary">
                 <source>icu.summary</source>
                 <target>Vsebuje podatke knjižnice ICU v določeni različici. Ta komponenta je opuščena od oktobra 2014, namesto nje uporabite komponento Intl.</target>
             </trans-unit>
-            <trans-unit id="icu.description">
-                <source>icu.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="optionsresolver.summary">
-                <source>optionsresolver.summary</source>
+            <trans-unit id="options-resolver.summary">
+                <source>options-resolver.summary</source>
                 <target>Pomaga nastaviti objekte s pomočjo opcije polj (arrays).</target>
-            </trans-unit>
-            <trans-unit id="optionsresolver.description">
-                <source>optionsresolver.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="process.summary">
                 <source>process.summary</source>
                 <target>Izvede ukaze v podprocesih.</target>
             </trans-unit>
-            <trans-unit id="process.description">
-                <source>process.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="propertyaccess.summary">
-                <source>propertyaccess.summary</source>
+            <trans-unit id="property-access.summary">
+                <source>property-access.summary</source>
                 <target>Ponuja funkcijo za branje in pisanje iz/v objekt ali polje s pomočjo enostavnega znakovnega zapisa.</target>
             </trans-unit>
-            <trans-unit id="propertyaccess.description">
-                <source>propertyaccess.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="propertyinfo.summary">
-                <source>propertyinfo.summary</source>
+            <trans-unit id="property-info.summary">
+                <source>property-info.summary</source>
                 <target>Izvleče informacije o lastnostih PHP razredov z uporabo meta podatkov popularnih virov (Doctrine, PHP Reflection, PHPdoc itd.)</target>
-            </trans-unit>
-            <trans-unit id="propertyinfo.description">
-                <source>propertyinfo.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="routing.summary">
                 <source>routing.summary</source>
                 <target>Poveže zahtevek HTTP z nizom nastavitvenih spremenljivk.</target>
             </trans-unit>
-            <trans-unit id="routing.description">
-                <source>routing.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="security.summary">
                 <source>security.summary</source>
                 <target>Ponuja infrastrukturo za sofisticirane sisteme pooblastil.</target>
-            </trans-unit>
-            <trans-unit id="security.description">
-                <source>security.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="serializer.summary">
                 <source>serializer.summary</source>
                 <target>Spremeni objekt v določeno obliko (XML, JSON, Yaml, ...) in obratno.</target>
             </trans-unit>
-            <trans-unit id="serializer.description">
-                <source>serializer.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="stopwatch.summary">
                 <source>stopwatch.summary</source>
                 <target>Ponuja način profiliranja kode.</target>
-            </trans-unit>
-            <trans-unit id="stopwatch.description">
-                <source>stopwatch.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="templating.summary">
                 <source>templating.summary</source>
                 <target>Ponuja vsa potrebna orodja za gradnjo vseh vrst sistemov predlog.</target>
             </trans-unit>
-            <trans-unit id="templating.description">
-                <source>templating.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="translation.summary">
                 <source>translation.summary</source>
                 <target>Ponuja orodja za internacionalizacijo vaše aplikacije.</target>
-            </trans-unit>
-            <trans-unit id="translation.description">
-                <source>translation.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="validator.summary">
                 <source>validator.summary</source>
                 <target>Ponuja orodja za potrjevanje razredov.</target>
             </trans-unit>
-            <trans-unit id="validator.description">
-                <source>validator.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="vardumper.summary">
-                <source>vardumper.summary</source>
+            <trans-unit id="var-dumper.summary">
+                <source>var-dumper.summary</source>
                 <target>Ponuja mehanizme za pregled skozi katerokoli arbitrarno PHP spremenljivko. </target>
-            </trans-unit>
-            <trans-unit id="vardumper.description">
-                <source>vardumper.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="yaml.summary">
                 <source>yaml.summary</source>
                 <target>Naloži in shrani datoteke YAML.</target>
-            </trans-unit>
-            <trans-unit id="yaml.description">
-                <source>yaml.description</source>
-                <target />
             </trans-unit>
         </body>
     </file>

--- a/translations/component.zh_CN.xliff
+++ b/translations/component.zh_CN.xliff
@@ -52,270 +52,150 @@
                 <source>asset.summary</source>
                 <target>管理URL生成和静态资源版本，比如CSS样式表，JavaScript文件和图片。</target>
             </trans-unit>
-            <trans-unit id="asset.description">
-                <source>asset.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="browserkit.summary">
-                <source>browserkit.summary</source>
+            <trans-unit id="browser-kit.summary">
+                <source>browser-kit.summary</source>
                 <target>模拟浏览器的功能。</target>
             </trans-unit>
-            <trans-unit id="browserkit.description">
-                <source>browserkit.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="classloader.summary">
-                <source>classloader.summary</source>
+            <trans-unit id="class-loader.summary">
+                <source>class-loader.summary</source>
                 <target>如果类（Class）采用了某些标准的PHP规则，便会自动加载到项目内。</target>
-            </trans-unit>
-            <trans-unit id="6">
-                <source>classloader.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="config.summary">
                 <source>config.summary</source>
                 <target>帮助您找到、加载、混合、自动填充、验证设置数值。</target>
             </trans-unit>
-            <trans-unit id="config.description">
-                <source>config.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="console.summary">
                 <source>console.summary</source>
                 <target>E简化创建美观和可测试的命令行界面。</target>
             </trans-unit>
-            <trans-unit id="console.description">
-                <source>console.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="cssselector.summary">
-                <source>cssselector.summary</source>
+            <trans-unit id="css-selector.summary">
+                <source>css-selector.summary</source>
                 <target>将 CSS 选择器转换为 XPath 语言。</target>
-            </trans-unit>
-            <trans-unit id="cssselector.description">
-                <source>cssselector.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="debug.summary">
                 <source>debug.summary</source>
                 <target>提供工具来简化 PHP 代码的调试。</target>
             </trans-unit>
-            <trans-unit id="debug.description">
-                <source>debug.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="dependencyinjection.summary">
-                <source>dependencyinjection.summary</source>
+            <trans-unit id="dependency-injection.summary">
+                <source>dependency-injection.summary</source>
                 <target>让您能够以统一的、集中的方式创建程序中的对象。</target>
             </trans-unit>
-            <trans-unit id="dependencyinjection.description">
-                <source>dependencyinjection.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="domcrawler.summary">
-                <source>domcrawler.summary</source>
+            <trans-unit id="dom-crawler.summary">
+                <source>dom-crawler.summary</source>
                 <target>简化 HTML 和 XML 文件内 DOM 的查找。</target>
             </trans-unit>
-            <trans-unit id="domcrawler.description">
-                <source>domcrawler.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="eventdispatcher.summary">
-                <source>eventdispatcher.summary</source>
+            <trans-unit id="event-dispatcher.summary">
+                <source>event-dispatcher.summary</source>
                 <target>提供一款 观察者设计模式 (Observer design pattern) 的轻量代码。</target>
             </trans-unit>
-            <trans-unit id="eventdispatcher.description">
-                <source>eventdispatcher.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="expressionlanguage.summary">
-                <source>expressionlanguage.summary</source>
+            <trans-unit id="expression-language.summary">
+                <source>expression-language.summary</source>
                 <target>Provides an engine that can compile and evaluate expressions.</target>
-            </trans-unit>
-            <trans-unit id="expressionlanguage.description">
-                <source>expressionlanguage.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="filesystem.summary">
                 <source>filesystem.summary</source>
                 <target>提供文件系统的基本操作。</target>
             </trans-unit>
-            <trans-unit id="filesystem.description">
-                <source>filesystem.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="finder.summary">
                 <source>finder.summary</source>
                 <target>提供易懂的流畅界面 (fluent interface)，来查找文件和文件夹。</target>
-            </trans-unit>
-            <trans-unit id="finder.description">
-                <source>finder.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="form.summary">
                 <source>form.summary</source>
                 <target>提供工具，以方便创建，处理和重用HTML表单。</target>
             </trans-unit>
-            <trans-unit id="form.description">
-                <source>form.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpfoundation.summary">
-                <source>httpfoundation.summary</source>
+            <trans-unit id="http-foundation.summary">
+                <source>http-foundation.summary</source>
                 <target>为 HTTP 规格提供一个面向对象的界面。</target>
             </trans-unit>
-            <trans-unit id="httpfoundation.description">
-                <source>httpfoundation.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpkernel.summary">
-                <source>httpkernel.summary</source>
+            <trans-unit id="http-kernel.summary">
+                <source>http-kernel.summary</source>
                 <target>为创建灵活的、高速的、基于 HTTP 的框架提供基本元件。</target>
-            </trans-unit>
-            <trans-unit id="httpkernel.description">
-                <source>httpkernel.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="locale.summary">
                 <source>locale.summary</source>
                 <target>如果 intl 扩展不存在，此组件可提供相关的功能。此组件于版本 2.3 过时，请使用 Intl 组件。</target>
             </trans-unit>
-            <trans-unit id="locale.description">
-                <source>locale.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="intl.summary">
                 <source>intl.summary</source>
                 <target>如果 intl 扩展不存在，此组件可提供相关的功能。</target>
-            </trans-unit>
-            <trans-unit id="intl.description">
-                <source>intl.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="icu.summary">
                 <source>icu.summary</source>
                 <target>包含ICU库的一个特定版本的数据。该组件在2014年10月废弃，使用国际组件代替。</target>
             </trans-unit>
-            <trans-unit id="icu.description">
-                <source>icu.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="optionsresolver.summary">
-                <source>optionsresolver.summary</source>
+            <trans-unit id="options-resolver.summary">
+                <source>options-resolver.summary</source>
                 <target>用设置数组来帮助您配置对象。</target>
-            </trans-unit>
-            <trans-unit id="optionsresolver.description">
-                <source>optionsresolver.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="process.summary">
                 <source>process.summary</source>
                 <target>以子流程执行指令。</target>
             </trans-unit>
-            <trans-unit id="process.description">
-                <source>process.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="propertyaccess.summary">
-                <source>propertyaccess.summary</source>
+            <trans-unit id="property-access.summary">
+                <source>property-access.summary</source>
                 <target>以存取简单字符串的方式来读取/储存对象或数组的数据。</target>
-            </trans-unit>
-            <trans-unit id="propertyaccess.description">
-                <source>propertyaccess.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="routing.summary">
                 <source>routing.summary</source>
                 <target>将 HTTP 访问转换为一组设置变量。</target>
             </trans-unit>
-            <trans-unit id="routing.description">
-                <source>routing.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="security.summary">
                 <source>security.summary</source>
                 <target>为建立复杂的授权系统提供设施。</target>
-            </trans-unit>
-            <trans-unit id="security.description">
-                <source>security.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="serializer.summary">
                 <source>serializer.summary</source>
                 <target>将对象转换为某种格式的数据（XML、JSON、Yaml……） 或反向转换。</target>
             </trans-unit>
-            <trans-unit id="serializer.description">
-                <source>serializer.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="stopwatch.summary">
                 <source>stopwatch.summary</source>
                 <target>提供一种分析代码的功能。</target>
-            </trans-unit>
-            <trans-unit id="stopwatch.description">
-                <source>stopwatch.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="templating.summary">
                 <source>templating.summary</source>
                 <target>提供工具制作任何种类的模板系统。</target>
             </trans-unit>
-            <trans-unit id="templating.description">
-                <source>templating.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="translation.summary">
                 <source>translation.summary</source>
                 <target>翻译组件工具</target>
-            </trans-unit>
-            <trans-unit id="translation.description">
-                <source>translation.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="validator.summary">
                 <source>validator.summary</source>
                 <target>提供验证类的工具。</target>
             </trans-unit>
-            <trans-unit id="validator.description">
-                <source>validator.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="yaml.summary">
                 <source>yaml.summary</source>
                 <target>加载和导出 YAML 文件。</target>
-            </trans-unit>
-            <trans-unit id="yaml.description">
-                <source>yaml.description</source>
-                <target />
             </trans-unit>
         </body>
     </file>

--- a/translations/component.zh_TW.xliff
+++ b/translations/component.zh_TW.xliff
@@ -48,157 +48,89 @@
                 <target>文献</target>
             </trans-unit>
 
-            <trans-unit id="browserkit.summary">
-                <source>browserkit.summary</source>
+            <trans-unit id="browser-kit.summary">
+                <source>browser-kit.summary</source>
                 <target>模拟浏览器的功能。</target>
             </trans-unit>
-            <trans-unit id="browserkit.description">
-                <source>browserkit.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="classloader.summary">
-                <source>classloader.summary</source>
+            <trans-unit id="class-loader.summary">
+                <source>class-loader.summary</source>
                 <target>如果类（Class）采用了某些标准的PHP规则，便会自动加载到项目内。</target>
-            </trans-unit>
-            <trans-unit id="6">
-                <source>classloader.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="config.summary">
                 <source>config.summary</source>
                 <target>帮助您找到、加载、混合、自动填充、验证设置数值。</target>
             </trans-unit>
-            <trans-unit id="config.description">
-                <source>config.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="console.summary">
                 <source>console.summary</source>
                 <target>简化创建美观和可测试的命令行界面。</target>
             </trans-unit>
-            <trans-unit id="console.description">
-                <source>console.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="cssselector.summary">
-                <source>cssselector.summary</source>
+            <trans-unit id="css-selector.summary">
+                <source>css-selector.summary</source>
                 <target>将 CSS 选择器转换为 XPath 语言。</target>
-            </trans-unit>
-            <trans-unit id="cssselector.description">
-                <source>cssselector.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="debug.summary">
                 <source>debug.summary</source>
                 <target>提供工具来简化 PHP 代码的调试。</target>
             </trans-unit>
-            <trans-unit id="debug.description">
-                <source>debug.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="dependencyinjection.summary">
-                <source>dependencyinjection.summary</source>
+            <trans-unit id="dependency-injection.summary">
+                <source>dependency-injection.summary</source>
                 <target>让您能够以统一的、集中的方式创建程序中的对象。</target>
             </trans-unit>
-            <trans-unit id="dependencyinjection.description">
-                <source>dependencyinjection.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="domcrawler.summary">
-                <source>domcrawler.summary</source>
+            <trans-unit id="dom-crawler.summary">
+                <source>dom-crawler.summary</source>
                 <target>简化 HTML 和 XML 文件内 DOM 的查找。</target>
             </trans-unit>
-            <trans-unit id="domcrawler.description">
-                <source>domcrawler.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="eventdispatcher.summary">
-                <source>eventdispatcher.summary</source>
+            <trans-unit id="event-dispatcher.summary">
+                <source>event-dispatcher.summary</source>
                 <target>提供一款 观察者设计模式 (Observer design pattern) 的轻量代码。</target>
             </trans-unit>
-            <trans-unit id="eventdispatcher.description">
-                <source>eventdispatcher.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="expressionlanguage.summary">
-                <source>expressionlanguage.summary</source>
+            <trans-unit id="expression-language.summary">
+                <source>expression-language.summary</source>
                 <target></target>
-            </trans-unit>
-            <trans-unit id="expressionlanguage.description">
-                <source>expressionlanguage.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="filesystem.summary">
                 <source>filesystem.summary</source>
                 <target>提供文件系统的基本操作。</target>
             </trans-unit>
-            <trans-unit id="filesystem.description">
-                <source>filesystem.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="finder.summary">
                 <source>finder.summary</source>
                 <target>提供易懂的流畅界面 (fluent interface)，来查找文件和文件夹。</target>
-            </trans-unit>
-            <trans-unit id="finder.description">
-                <source>finder.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="form.summary">
                 <source>form.summary</source>
                 <target></target>
             </trans-unit>
-            <trans-unit id="form.description">
-                <source>form.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpfoundation.summary">
-                <source>httpfoundation.summary</source>
+            <trans-unit id="http-foundation.summary">
+                <source>http-foundation.summary</source>
                 <target>为 HTTP 规格提供一个面向对象的界面。</target>
             </trans-unit>
-            <trans-unit id="httpfoundation.description">
-                <source>httpfoundation.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="httpkernel.summary">
-                <source>httpkernel.summary</source>
+            <trans-unit id="http-kernel.summary">
+                <source>http-kernel.summary</source>
                 <target>为创建灵活的、高速的、基于 HTTP 的框架提供基本元件。</target>
-            </trans-unit>
-            <trans-unit id="httpkernel.description">
-                <source>httpkernel.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="locale.summary">
                 <source>locale.summary</source>
                 <target>如果 intl 扩展不存在，此组件可提供相关的功能。此组件于版本 2.3 过时，请使用 Intl 组件。</target>
             </trans-unit>
-            <trans-unit id="locale.description">
-                <source>locale.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="intl.summary">
                 <source>intl.summary</source>
                 <target>如果 intl 扩展不存在，此组件可提供相关的功能。</target>
-            </trans-unit>
-            <trans-unit id="intl.description">
-                <source>intl.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="icu.summary">
@@ -206,108 +138,60 @@
                 <target>包含某一版本的 ICU 库的资料。由
                     Contains the data of the ICU library in a specific version. Use it through the API of the Intl 组件调用。</target>
             </trans-unit>
-            <trans-unit id="icu.description">
-                <source>icu.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="optionsresolver.summary">
-                <source>optionsresolver.summary</source>
+            <trans-unit id="options-resolver.summary">
+                <source>options-resolver.summary</source>
                 <target>用设置数组来帮助您配置对象。</target>
-            </trans-unit>
-            <trans-unit id="optionsresolver.description">
-                <source>optionsresolver.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="process.summary">
                 <source>process.summary</source>
                 <target>以子流程执行指令。</target>
             </trans-unit>
-            <trans-unit id="process.description">
-                <source>process.description</source>
-                <target />
-            </trans-unit>
 
-            <trans-unit id="propertyaccess.summary">
-                <source>propertyaccess.summary</source>
+            <trans-unit id="property-access.summary">
+                <source>property-access.summary</source>
                 <target>以存取简单字符串的方式来读取/储存对象或数组的数据。</target>
-            </trans-unit>
-            <trans-unit id="propertyaccess.description">
-                <source>propertyaccess.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="routing.summary">
                 <source>routing.summary</source>
                 <target>将 HTTP 访问转换为一组设置变量。</target>
             </trans-unit>
-            <trans-unit id="routing.description">
-                <source>routing.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="security.summary">
                 <source>security.summary</source>
                 <target>为建立复杂的授权系统提供设施。</target>
-            </trans-unit>
-            <trans-unit id="security.description">
-                <source>security.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="serializer.summary">
                 <source>serializer.summary</source>
                 <target>将对象转换为某种格式的数据（XML、JSON、Yaml……） 或反向转换。</target>
             </trans-unit>
-            <trans-unit id="serializer.description">
-                <source>serializer.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="stopwatch.summary">
                 <source>stopwatch.summary</source>
                 <target>提供一种分析代码的功能。</target>
-            </trans-unit>
-            <trans-unit id="stopwatch.description">
-                <source>stopwatch.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="templating.summary">
                 <source>templating.summary</source>
                 <target>提供工具制作任何种类的模板系统。</target>
             </trans-unit>
-            <trans-unit id="templating.description">
-                <source>templating.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="translation.summary">
                 <source>translation.summary</source>
                 <target>翻译组件</target>
-            </trans-unit>
-            <trans-unit id="translation.description">
-                <source>translation.description</source>
-                <target />
             </trans-unit>
 
             <trans-unit id="validator.summary">
                 <source>validator.summary</source>
                 <target></target>
             </trans-unit>
-            <trans-unit id="validator.description">
-                <source>validator.description</source>
-                <target />
-            </trans-unit>
 
             <trans-unit id="yaml.summary">
                 <source>yaml.summary</source>
                 <target>加载和导出 YAML 文件。</target>
-            </trans-unit>
-            <trans-unit id="yaml.description">
-                <source>yaml.description</source>
-                <target />
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
And removed the `.description` translation because it's empty and used nowhere.