### PR TITLE
Added the new "Trademark and Licenses" page

### DIFF
--- a/translations/marketing.en.xliff
+++ b/translations/marketing.en.xliff
@@ -33,20 +33,20 @@
                 <target>Case Studies</target>
             </trans-unit>
             <trans-unit id="1-6">
-                <source>menu.what_is_symfony.versioning_policy</source>
-                <target>Versioning Policy</target>
+                <source>menu.what_is_symfony.symfony_roadmap</source>
+                <target>Symfony Roadmap</target>
             </trans-unit>
             <trans-unit id="1-7">
                 <source>menu.what_is_symfony.security_policy</source>
                 <target>Security Policy</target>
             </trans-unit>
             <trans-unit id="1-8">
-                <source>menu.what_is_symfony.license</source>
-                <target>License</target>
+                <source>menu.about.logo</source>
+                <target>Logo &amp; Screenshots</target>
             </trans-unit>
             <trans-unit id="1-9">
-                <source>menu.what_is_symfony.symfony_roadmap</source>
-                <target>Roadmap</target>
+                <source>menu.what_is_symfony.license</source>
+                <target>Trademark &amp; Licenses</target>
             </trans-unit>
             <trans-unit id="1-10">
                 <source>menu.what_is_symfony.symfony_legacy</source>
@@ -66,7 +66,6 @@
                 <source>menu.community</source>
                 <target>Community</target>
             </trans-unit>
-
             <trans-unit id="4-1">
                 <source>menu.community.sensiolabs_connect</source>
                 <target>SensioLabs Connect</target>
@@ -107,7 +106,6 @@
                 <source>menu.about</source>
                 <target>About</target>
             </trans-unit>
-
             <trans-unit id="71">
                 <source>menu.about.sensiolabs</source>
                 <target>SensioLabs</target>
@@ -115,14 +113,6 @@
             <trans-unit id="72">
                 <source>menu.about.contributors</source>
                 <target>Contributors</target>
-            </trans-unit>
-            <trans-unit id="73">
-                <source>menu.about.tradmeark_logo_policy</source>
-                <target>Trademark &amp; Logo Policy</target>
-            </trans-unit>
-            <trans-unit id="74">
-                <source>menu.about.logo</source>
-                <target>Logo</target>
             </trans-unit>
             <trans-unit id="75">
                 <source>menu.about.jobs</source>

--- a/views/en/what_is_symfony/license.html.twig
+++ b/views/en/what_is_symfony/license.html.twig
@@ -1,0 +1,50 @@
+{% block title 'Symfony Trademark & Licenses' %}
+{% block keywords '' %}
+{% block description '' %}
+
+{% block trademark_title 'Symfony Trademark' %}
+{% block trademark_content %}
+    <p>
+        Symfony &trade; is a trademark of Fabien Potencier. All rights reserved.
+        <a href="{{ marketing_path('trademark') }}">See trademark details</a>.
+    </p>
+{% endblock %}
+
+{% block logo_title 'Symfony Logo' %}
+{% block logo_content %}
+    <p>
+        Symfony logo is an original artwork created by
+        <a href="http://sensiolabs.com">SensioLabs</a> and published under the
+        terms of the copyright license.
+        <a href="{{ marketing_path('trademark') }}">See logo usage guidelines</a>.
+    </p>
+{% endblock %}
+
+{% block website_title 'Symfony Website' %}
+{% block website_content %}
+    <p>
+        Symfony Website design is an original artwork created by
+        <a href="http://sensiolabs.com">SensioLabs</a> and published under the
+        terms of the copyright license. Unless stated to the contrary, the
+        website contents are published under the terms of the Creative Commons
+        Attribution-Share Alike 3.0 Unported License.
+        <a href="http://creativecommons.org/licenses/by-sa/3.0/">See license details</a>.
+    </p>
+{% endblock %}
+
+{% block code_title 'Symfony Code' %}
+{% block code_content %}
+    <p>
+        Symfony Source Code is published under the terms of the MIT License.
+        <a href="{{ doc_path({ page: 'contributing/code/license', version: 'master' }) }}">See code license details</a>.
+    </p>
+{% endblock %}
+
+{% block documentation_title 'Symfony Documentation' %}
+{% block documentation_content %}
+    <p>
+        Symfony Documentation is published under the terms of the Creative Commons
+        Attribution-Share Alike 3.0 Unported license.
+        <a href="{{ doc_path({ page: 'contributing/doc/license', version: 'master' }) }}">See documentation license details</a>.
+    </p>
+{% endblock %}


### PR DESCRIPTION
This page will replace the existing http://symfony.com/license page. We've also tweaked the menu of the "What is Symfony" section. This is how it looks:

![f0d77a78-4c0c-11e5-8967-603519941e81](https://cloud.githubusercontent.com/assets/73419/11033469/adf48bc6-86e3-11e5-82f5-1399b46d5845.png)
