### PR TITLE
Updated the list of components used by Drupal 8

### DIFF
--- a/projects/drupal.yml
+++ b/projects/drupal.yml
@@ -3,11 +3,15 @@ url: http://drupal.org
 dependencies: []
 components:
     - ClassLoader
+    - Console
+    - CssSelector
     - DependencyInjection
     - EventDispatcher
     - HttpFoundation
     - HttpKernel
+    - Process
     - Routing
     - Serializer
+    - Translation
     - Validator
     - Yaml


### PR DESCRIPTION
The list of components is available at https://github.com/drupal/drupal/blob/8.0.x/core/composer.json