### PR TITLE
Add EventDispatcher to Magento

### DIFF
--- a/projects/magento.yml
+++ b/projects/magento.yml
@@ -3,3 +3,4 @@ url: http://magento.com
 dependencies: []
 components:
     - Console
+    - EventDispatcher


### PR DESCRIPTION
According to https://github.com/magento/magento2/blob/develop/composer.json#L43, Magento also uses the `EventDispatcher` component.