### PR TITLE
Make Support channel choice more explicit

### DIFF
--- a/views/en/community/support.html.twig
+++ b/views/en/community/support.html.twig
@@ -5,11 +5,11 @@
 {% block title_community_support %}Community Support{% endblock %}
 {% block stackoverflow_support %}
     Use <a href="http://stackoverflow.com/questions/tagged/symfony">Stack Overflow</a>
-    <span>to ask and answer Symfony questions.</span>
+    <span>to ask/answer specific Symfony problems.</span>
 {% endblock %}
 {% block irc_support %}
     Use the <a href="{{ marketing_path('irc') }}">#symfony IRC channel</a>
-    <span>to get real-time support.</span>
+    <span>to get real-time support or advice.</span>
 {% endblock %}
 
 {% block title_professional_support %}Professional Support{% endblock %}

--- a/views/nl/community/support.html.twig
+++ b/views/nl/community/support.html.twig
@@ -5,11 +5,11 @@
 {% block title_community_support %}Community Support{% endblock %}
 {% block stackoverflow_support %}
     Gebruik <a href="http://stackoverflow.com/questions/tagged/symfony">Stack Overflow</a>
-    <span>om Symfony vragen te stellen en te beantwoorden.</span>
+    <span>om hulp te vragen/geven voor specifieke Symfony problemen.</span>
 {% endblock %}
 {% block irc_support %}
     Gebruik het <a href="{{ marketing_path('irc') }}">#symfony IRC kanaal</a>
-    <span>om real-time ondersteuning te krijgen.</span>
+    <span>om real-time ondersteuning of advies te krijgen.</span>
 {% endblock %}
 
 {% block title_professional_support %}Professionele Support{% endblock %}


### PR DESCRIPTION
While listening to [the latest Sound Of Symfony episode](http://www.soundofsymfony.com/episode/episode-12/), it was clear that there can be some confusion for beginners on where to find help for their problems.

I think one thing that causes this is the fact that we show people 2 ways to get help: SO and IRC. But we don't really tell people which channel to use for which type of questions. I think we need to make this more explicit. Especially as SO is maintained by lots of non-Symfony people. If people ask a wrong type of question of SO, they will probably have a not-so-nice experience of downvoting and closing.

In general, people can use IRC for everything they want (even for just advice or to have someone to scream to after hours of debugging). SO is targetted for only specific problems that have clear answers.

At last, what about linking to the webchat version of freenode IRC (https://webchat.freenode.net/)? I guess not a lot of people are familar with it.

*Unfortunately, I don't speak lots of languages, so other people will have to update the other translations.*

/cc @weaverryan