### PR TITLE
Added missing translations for Components

### DIFF
--- a/translations/component.en.xliff
+++ b/translations/component.en.xliff
@@ -58,6 +58,11 @@
                 <target>Simulates the behavior of a web browser.</target>
             </trans-unit>
 
+            <trans-unit id="cache.summary">
+                <source>cache.summary</source>
+                <target>Implements PSR-6 and PSR-16 caching mechanisms and provides adapters for popular caching backends (Redis, Memcache, APCu, etc.)</target>
+            </trans-unit>
+
             <trans-unit id="class-loader.summary">
                 <source>class-loader.summary</source>
                 <target>Loads your project classes automatically if they follow some standard PHP conventions.</target>
@@ -118,8 +123,8 @@
                 <target>Provides tools to easy creating, processing and reusing HTML forms.</target>
             </trans-unit>
 
-            <trans-unit id="guard.summary">
-                <source>guard.summary</source>
+            <trans-unit id="security-guard.summary">
+                <source>security-guard.summary</source>
                 <target>Brings many layers of authentication together, making it much easier to create complex authentication systems where you have total control.</target>
             </trans-unit>
 
@@ -213,9 +218,89 @@
                 <target>Provides mechanisms for walking through any arbitrary PHP variable. </target>
             </trans-unit>
 
+            <trans-unit id="workflow.summary">
+                <source>workflow.summary</source>
+                <target>Provides tools for managing a workflow or finite state machine.</target>
+            </trans-unit>
+
             <trans-unit id="yaml.summary">
                 <source>yaml.summary</source>
                 <target>Loads and dumps YAML files.</target>
+            </trans-unit>
+
+            <trans-unit id="yaml.summary">
+                <source>yaml.summary</source>
+                <target>Loads and dumps YAML files.</target>
+            </trans-unit>
+
+            <trans-unit id="yaml.summary">
+                <source>yaml.summary</source>
+                <target>Loads and dumps YAML files.</target>
+            </trans-unit>
+
+            <trans-unit id="polyfill-apcu.summary">
+                <source>polyfill-apcu.summary</source>
+                <target>Provides apcu_* functions and the APCUIterator class to users of the legacy APC extension.</target>
+            </trans-unit>
+
+            <trans-unit id="polyfill-php54.summary">
+                <source>polyfill-php54.summary</source>
+                <target>Provides functions unavailable in releases prior to PHP 5.4.</target>
+            </trans-unit>
+
+            <trans-unit id="polyfill-php55.summary">
+                <source>polyfill-php55.summary</source>
+                <target>Provides functions unavailable in releases prior to PHP 5.5.</target>
+            </trans-unit>
+
+            <trans-unit id="polyfill-php56.summary">
+                <source>polyfill-php56.summary</source>
+                <target>Provides functions unavailable in releases prior to PHP 5.6.</target>
+            </trans-unit>
+
+            <trans-unit id="polyfill-php70.summary">
+                <source>polyfill-php70.summary</source>
+                <target>Provides functions unavailable in releases prior to PHP 7.0.</target>
+            </trans-unit>
+
+            <trans-unit id="polyfill-php71.summary">
+                <source>polyfill-php71.summary</source>
+                <target>Provides functions unavailable in releases prior to PHP 7.1.</target>
+            </trans-unit>
+
+            <trans-unit id="polyfill-iconv.summary">
+                <source>polyfill-iconv.summary</source>
+                <target>Provides a native PHP implementation of the php.net/iconv functions.</target>
+            </trans-unit>
+
+            <trans-unit id="polyfill-intl-grapheme.summary">
+                <source>polyfill-intl-grapheme.summary</source>
+                <target>Provides a partial, native PHP implementation of the Grapheme functions from the Intl extension.</target>
+            </trans-unit>
+
+            <trans-unit id="polyfill-intl-icu.summary">
+                <source>polyfill-intl-icu.summary</source>
+                <target>Provides a collection of functions/classes using the symfony/intl package when the Intl extension is not installed.</target>
+            </trans-unit>
+
+            <trans-unit id="polyfill-intl-normalizer.summary">
+                <source>polyfill-intl-normalizer.summary</source>
+                <target>Provides a fallback implementation for the Normalizer class provided by the Intl extension.</target>
+            </trans-unit>
+
+            <trans-unit id="polyfill-mbstring.summary">
+                <source>polyfill-mbstring.summary</source>
+                <target>Provides a partial, native PHP implementation for the Mbstring extension.</target>
+            </trans-unit>
+
+            <trans-unit id="polyfill-util.summary">
+                <source>polyfill-util.summary</source>
+                <target>Provides binary-safe string functions, using the mbstring extension when available.</target>
+            </trans-unit>
+
+            <trans-unit id="polyfill-xml.summary">
+                <source>polyfill-xml.summary</source>
+                <target>Provides a fallback implementation for the following functions in the abscense of the XML extension.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
The `guard.summary` -> `security-guard.summary` change is needed because of some change done on symfony.com in coordination with this PR.