### PR TITLE
Remove DotEnv from the list of documented components

### DIFF
--- a/projects/_components.yml
+++ b/projects/_components.yml
@@ -7,7 +7,7 @@ Console:             { docUrl: console.html }
 CssSelector:         { docUrl: css_selector.html }
 Debug:               { docUrl: debug.html }
 DependencyInjection: { docUrl: dependency_injection.html }
-Dotenv:              { docUrl: dotenv.html }
+Dotenv:              { docUrl: ~ }
 DomCrawler:          { docUrl: dom_crawler.html }
 EventDispatcher:     { docUrl: event_dispatcher.html }
 ExpressionLanguage:  { docUrl: expression_language.html }


### PR DESCRIPTION
Related to https://github.com/symfony/symfony-docs/issues/7526

Problem: DorEnv is only documented on "master", so all the "current" links return 404. The only fix that doesn't involve a lot of work is consider the component not documented until Symfony 3.3 is released (at the end of May 2017). Undocumented components are not listed on the symfony.com docs sidebar.