### PR TITLE
Automate how dependencies are found for each project

### DIFF
--- a/projects/aimeos.yml
+++ b/projects/aimeos.yml
@@ -1,42 +1,8 @@
 name: Aimeos e-commerce components
 url: https://aimeos.org/Symfony
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/aimeos/aimeos-core/blob/master/composer.json
+    - https://github.com/aimeos/aimeos-symfony/blob/master/composer.json
 description: |
     Aimeos is a full-featured online shop and market place bundle which
     integrates the Aimeos e-commerce library into Symfony. It offers a

--- a/projects/akeneo.yml
+++ b/projects/akeneo.yml
@@ -1,42 +1,8 @@
 name: Akeneo PIM
 url: http://akeneo.com
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/akeneo/pim-community-dev/blob/master/composer.json
+    - https://github.com/akeneo/pim-community-standard/blob/master/composer.json
 description: |
     Akeneo is an open source Product Information Management (PIM) system
     designed for retailers looking for efficient answers to their

--- a/projects/apiplatform.yml
+++ b/projects/apiplatform.yml
@@ -1,42 +1,8 @@
 name: API Platform
 url: https://api-platform.com
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/api-platform/api-platform/blob/master/composer.json
+    - https://github.com/api-platform/core/blob/master/composer.json
 description: |
     API Platform is an Open Source web framework for API-first projects.
     Describe the API's data model or import an existing one from Schema.org

--- a/projects/assetic.yml
+++ b/projects/assetic.yml
@@ -1,7 +1,7 @@
 name: Assetic
 url: http://github.com/kriswallsmith/assetic
-components:
-    - Process
+dependencies:
+    - https://github.com/kriswallsmith/assetic/blob/master/composer.json
 description: |
     Assetic is an asset management framework for PHP. It combines two
     major ideas: assets and filters. The assets are files such as CSS,

--- a/projects/backbee.yml
+++ b/projects/backbee.yml
@@ -1,21 +1,8 @@
 name: BackBee
 url: http://www.backbee.com/
-components:
-    - Config
-    - Console
-    - Debug
-    - DependencyInjection
-    - EventDispatcher
-    - Expression Language
-    - Filesystem
-    - HttpFoundation
-    - HttpKernel
-    - Routing
-    - Security
-    - Serializer
-    - Translation
-    - Validator
-    - Yaml
+dependencies:
+    - https://github.com/backbee/backbee-cms/blob/master/composer.json
+    - https://github.com/backbee/backbee-php/blob/master/composer.json
 description: |
     BackBee is an open source CMS designed to revolutionize user experience.
     It uses "On Page Editing" architecture making content contribution

--- a/projects/behat.yml
+++ b/projects/behat.yml
@@ -1,14 +1,10 @@
 name: Behat
 url: http://behat.org
-components:
-    - ClassLoader
-    - Config
-    - Console
-    - DependencyInjection
-    - EventDispatcher
-    - Finder
-    - Translation
-    - Yaml
+dependencies:
+    - https://github.com/Behat/Behat/blob/master/composer.json
+    - https://github.com/Behat/Gherkin/blob/master/composer.json
+    - https://github.com/Behat/WebApiExtension/blob/master/composer.json
+    - https://github.com/Behat/MinkExtension/blob/master/composer.json
 description: |
     Behat is an open source behavior-driven development framework for PHP
     5.3 and 5.4. What is behavior-driven development, you ask? It's the

--- a/projects/bolt.yml
+++ b/projects/bolt.yml
@@ -1,14 +1,7 @@
 name: Bolt
 url: http://bolt.cm
-components:
-    - Config
-    - Console
-    - Filesystem
-    - Finder
-    - Form
-    - Translation
-    - Validator
-    - Yaml
+dependencies:
+    - https://github.com/bolt/bolt/blob/master/composer.json
 description: |
     Bolt is a tool for Content Management, which strives to be as simple
     and straightforward as possible. It is quick to set up, easy to

--- a/projects/carew.yml
+++ b/projects/carew.yml
@@ -1,14 +1,7 @@
 name: Carew
 url: http://carew.github.io
-components:
-    - Console
-    - CssSelector
-    - Debug
-    - DomCrawler
-    - EventDispatcher
-    - Filesystem
-    - Finder
-    - Yaml
+dependencies:
+    - https://github.com/carew/carew/blob/master/composer.json
 description: |
     Carew is another static site / blog generator. Write some blog posts or
     pages in Markdown, Carew will render them in HTML. It provides auto

--- a/projects/codeception.yml
+++ b/projects/codeception.yml
@@ -1,13 +1,7 @@
 name: Codeception
 url: http://codeception.com/
-components:
-    - BrowserKit
-    - Console
-    - CssSelector
-    - DomCrawler
-    - EventDispatcher
-    - Finder
-    - Yaml
+dependencies:
+    - https://github.com/Codeception/Codeception/blob/master/composer.json
 description: |
     Codeception is a full-stack testing framework which incorporates
     acceptance, functional, and unit testing. It uses a simple PHP DSL to

--- a/projects/composer.yml
+++ b/projects/composer.yml
@@ -1,9 +1,7 @@
 name: Composer
 url: http://getcomposer.org
-components:
-    - Console
-    - Finder
-    - Process
+dependencies:
+    - https://github.com/composer/composer/blob/master/composer.json
 description: |
     Composer is a tool for dependency management in PHP. It allows you to
     declare the dependent libraries your project needs and it will install

--- a/projects/concrete5.yml
+++ b/projects/concrete5.yml
@@ -1,12 +1,7 @@
 name: concrete5
 url: http://www.concrete5.org/
-components:
-    - ClassLoader
-    - EventDispatcher
-    - HttpFoundation
-    - HttpKernel
-    - Routing
-    - Serializer
+dependencies:
+    - https://github.com/concrete5/concrete5-core/blob/develop/composer.json
 description: |
     Concrete5 is an open source CMS designed to revolutionize user experience.
     Go to any page in your site, and an editing toolbar gives you all the

--- a/projects/contao.yml
+++ b/projects/contao.yml
@@ -1,42 +1,8 @@
 name: Contao
 url: https://contao.org
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/contao/standard-edition/blob/master/composer.json
+    - https://github.com/contao/core-bundle/blob/master/composer.json
 description: |
     Contao is an accessible open source content management system,
     first published in 2006. Starting with version 4 (released in spring 2015),

--- a/projects/csbill.yml
+++ b/projects/csbill.yml
@@ -1,42 +1,7 @@
 name: CSBill
 url: http://csbill.org
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/CSBill/CSBill/blob/master/composer.json
 description: |
     CSBill is an open-source billing application designed for ease of use and to
     simplify accounting for freelancers or big companies. The main features

--- a/projects/deployer.yml
+++ b/projects/deployer.yml
@@ -1,10 +1,7 @@
 name: Deployer
 url: https://deployer.org/
-components:
-    - Console
-    - Finder
-    - Process
-    - Yaml
+dependencies:
+    - https://github.com/deployphp/deployer/blob/master/composer.json
 description: |
     A deployment tool written in PHP with support for popular frameworks
     out of the box. Simple setup process and a minimal learning curve.

--- a/projects/doctrine.yml
+++ b/projects/doctrine.yml
@@ -1,8 +1,9 @@
 name: Doctrine
 url: http://doctrine-project.org
-components:
-    - Console
-    - Yaml
+dependencies:
+    - https://github.com/doctrine/doctrine2/blob/master/composer.json
+    - https://github.com/doctrine/dbal/blob/master/composer.json
+    - https://github.com/doctrine/common/blob/master/composer.json
 description: |
     Object relational mapper (ORM) for PHP that sits on top of a powerful
     database abstraction layer (DBAL). One of its key features is the

--- a/projects/drupal.yml
+++ b/projects/drupal.yml
@@ -1,21 +1,7 @@
 name: Drupal
 url: http://drupal.org
-components:
-    - ClassLoader
-    - Console
-    - CssSelector
-    - DependencyInjection
-    - EventDispatcher
-    - HttpFoundation
-    - HttpKernel
-    - "PHPUnit Bridge"
-    - "Polyfill Iconv"
-    - Process
-    - Routing
-    - Serializer
-    - Translation
-    - Validator
-    - Yaml
+dependencies:
+    - https://github.com/drupal/core/blob/8.4.x/composer.json
 description: |
     Drupal is an open source content management platform powering millions
     of websites and applications. It's built, used, and supported by an

--- a/projects/drupalconsole.yml
+++ b/projects/drupalconsole.yml
@@ -1,18 +1,8 @@
 name: Drupal Console
 url: http://drupalconsole.com/
-components:
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - EventDispatcher
-    - Filesystem
-    - Finder
-    - HttpFoundation
-    - Translation
-    - Yaml
+dependencies:
+    - https://github.com/hechoendrupal/drupal-console-core/blob/master/composer.json
+    - https://github.com/hechoendrupal/drupal-console/blob/master/composer.json
 description: |
     The Drupal Console is a suite of tools that provide a command line
     interface (CLI) to generate boilerplate code and interact with a

--- a/projects/drush.yml
+++ b/projects/drush.yml
@@ -1,13 +1,7 @@
 name: Drush
 url: http://www.drush.org/
-components:
-    - Config
-    - Console
-    - EventDispatcher
-    - Finder
-    - Process
-    - VarDumper
-    - Yaml
+dependencies:
+    - https://github.com/drush-ops/drush/blob/master/composer.json
 description: |
     Drush is a command line shell and scripting interface for Drupal, a veritable
     Swiss Army knife designed to make life easier for those of us who spend some

--- a/projects/easybook.yml
+++ b/projects/easybook.yml
@@ -1,18 +1,7 @@
 name: Easybook
 url: http://easybook-project.org
-components:
-    - BrowserKit
-    - ClassLoader
-    - Config
-    - Console
-    - CssSelector
-    - Finder
-    - Form
-    - Process
-    - Security
-    - Translation
-    - Validator
-    - Yaml
+dependencies:
+    - https://github.com/javiereguiluz/easybook/blob/master/composer.json
 description: |
     Easybook is an application that lets you easily publish books in
     various electronic formats. Although it was originally designed to

--- a/projects/eccube.yml
+++ b/projects/eccube.yml
@@ -1,17 +1,7 @@
 name: eccube
 url: http://www.ec-cube.net/
-components:
-    - Config
-    - Console
-    - EventDispatcher
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Translation
-    - Validator
-    - Yaml
+dependencies:
+    - https://github.com/EC-CUBE/ec-cube/blob/master/composer.json
 description: |
     EC-CUBE is an open source package used to build e-commerce sites.  It is the
     most popular shopping cart system in Japan. Since the release of the

--- a/projects/elcodi.yml
+++ b/projects/elcodi.yml
@@ -1,21 +1,7 @@
 name: Elcodi
 url: http://elcodi.io
-components:
-    - BrowserKit
-    - ClassLoader
-    - Config
-    - Console
-    - EventDispatcher
-    - ExpressionLanguage
-    - Finder
-    - FrameworkBundle
-    - HttpFoundation
-    - HttpKernel
-    - Process
-    - Routing
-    - Security
-    - Validator
-    - Yaml
+dependencies:
+    - https://github.com/elcodi/elcodi/blob/master/composer.json
 description: |
     Elcodi is an e-commerce platform on top of Symfony, specifically created
     to build and quickly scale your project. Based on loosely coupled

--- a/projects/ezpublish.yml
+++ b/projects/ezpublish.yml
@@ -1,42 +1,8 @@
 name: eZ Publish
 url: http://ez.no/Community
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/ezsystems/ezplatform/blob/master/composer.json
+    - https://github.com/ezsystems/ezplatform-ee/blob/master/composer.json
 description: |
     The eZ Publish Community project serves as the foundation for the eZ Publish
     Enterprise Edition, which is built for business-critical digital

--- a/projects/flarum.yml
+++ b/projects/flarum.yml
@@ -1,10 +1,7 @@
 name: Flarum
 url: http://flarum.org/
-components:
-    - Console
-    - HttpFoundation
-    - Translation
-    - Yaml
+dependencies:
+    - https://github.com/flarum/core/blob/master/composer.json
 description: |
     Flarum is the next-generation forum software that makes online discussion
     fun. It's simple, fast, and free.

--- a/projects/forkcms.yml
+++ b/projects/forkcms.yml
@@ -1,15 +1,7 @@
 name: Fork CMS
 url: http://fork-cms.com
-components:
-    - DependencyInjection
-    - EventDispatcher
-    - HttpFoundation
-    - HttpKernel
-    - Filesystem
-    - Finder
-    - Filesystem
-    - Console
-    - Config
+dependencies:
+    - https://github.com/forkcms/forkcms/blob/master/composer.json
 description: |
     Fork CMS is dedicated to creating a user friendly environment to build,
     monitor and update your website. We take great pride in being the

--- a/projects/goutte.yml
+++ b/projects/goutte.yml
@@ -1,11 +1,7 @@
 name: Goutte
 url: http://github.com/fabpot/Goutte
-components:
-    - BrowserKit
-    - CssSelector
-    - DomCrawler
-    - Finder
-    - Process
+dependencies:
+    - https://github.com/FriendsOfPHP/Goutte/blob/master/composer.json
 description: |
     Goutte is a screen scraping and web crawling library for PHP. Goutte
     provides a nice API to crawl websites and extract data from the HTML/XML

--- a/projects/grav.yml
+++ b/projects/grav.yml
@@ -1,11 +1,8 @@
 name: Grav
 url: http://getgrav.org
-components:
-    - Console
-    - EventDispatcher
-    - "Polyfill Iconv"
-    - VarDumper
-    - YAML
+dependencies:
+    - https://github.com/getgrav/grav/blob/develop/composer.json
+    - https://github.com/getgrav/grav-plugin-admin/blob/develop/composer.json
 description: |
     Grav is a Modern, Fast, Simple and Flexible flat-file CMS. While Grav is
     intentionally minimal, the extensive plugin architecture allows it to be

--- a/projects/initcms.yml
+++ b/projects/initcms.yml
@@ -1,42 +1,7 @@
 name: init CMS
 url: http://initcms.com/
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/networking/init-cms-bundle/blob/master/composer.json
 description: |
     The InitCmsBundle is a small flexible cms core based on Symfony
     which can be used as a standalone CMS or integrated into any existing

--- a/projects/joomla.yml
+++ b/projects/joomla.yml
@@ -1,13 +1,8 @@
 name: Joomla!
 url: http://www.joomla.org/
-components:
-    # https://github.com/joomla/framework.joomla.org/blob/master/composer.json
-    - Asset
-    - WebLink
-    # https://github.com/joomla/joomla-cms/blob/staging/composer.json
-    - "Polyfill PHP 5.5"
-    - "Polyfill PHP 5.6"
-    - Yaml
+dependencies:
+    - https://github.com/joomla/joomla-cms/blob/staging/composer.json
+    - https://github.com/joomla/framework.joomla.org/blob/master/composer.json
 description: |
     Joomla is an award-winning content management system (CMS), which
     enables you to build Web sites and powerful online applications. Many

--- a/projects/kunstmaanbundles.yml
+++ b/projects/kunstmaanbundles.yml
@@ -1,42 +1,7 @@
 name: Kunstmaan Bundles
 url: http://bundles.kunstmaan.be
-components:
-      - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/master/composer.json
 description: |
     The Kunstmaan Bundles CMS is an advanced yet user-friendly content
     management system, based on the full stack Symfony framework combined

--- a/projects/ladybug.yml
+++ b/projects/ladybug.yml
@@ -1,11 +1,7 @@
 name: Ladybug
 url: https://github.com/raulfraile/ladybug
-components:
-    - Console
-    - Finder
-    - DependencyInjection
-    - Config
-    - DomCrawler
+dependencies:
+    - https://github.com/raulfraile/ladybug/blob/master/composer.json
 description: |
     Ladybug provides an easy and extensible var_dump / print_r replacement
     for PHP 5.3+ projects. Any PHP variable, object or resource can be

--- a/projects/laravel.yml
+++ b/projects/laravel.yml
@@ -1,16 +1,14 @@
 name: Laravel
 url: http://laravel.com
-components:
-    - Console
-    - CssSelector
-    - Debug
-    - DomCrawler
-    - Finder
-    - HttpFoundation
-    - HttpKernel
-    - Process
-    - Routing
-    - VarDumper
+dependencies:
+    - https://github.com/laravel/framework/blob/master/composer.json
+    - https://github.com/laravel/installer/blob/master/composer.json
+    - https://github.com/laravel/cashier/blob/master/composer.json
+    - https://github.com/laravel/valet/blob/master/composer.json
+    - https://github.com/laravel/tinker/blob/master/composer.json
+    - https://github.com/laravel/passport/blob/master/composer.json
+    - https://github.com/laravel/dusk/blob/master/composer.json
+    - https://github.com/laravel/envoy/blob/master/composer.json
 description: |
     Laravel is a web application framework with expressive, elegant
     syntax. We believe development must be an enjoyable, creative

--- a/projects/lumen.yml
+++ b/projects/lumen.yml
@@ -1,8 +1,8 @@
 name: Lumen
 url: https://lumen.laravel.com/
-components:
-    - HttpFoundation
-    - HttpKernel
+dependencies:
+    - https://github.com/laravel/lumen-framework/blob/master/composer.json
+    - https://github.com/laravel/lumen-installer/blob/master/composer.json
 description: |
     Lumen is a micro-framework based on the same foundation as Laravel and built
     for developing microservices.

--- a/projects/magento.yml
+++ b/projects/magento.yml
@@ -1,9 +1,8 @@
 name: Magento
 url: http://magento.com
-components:
-    - Console
-    - EventDispatcher
-    - Process
+dependencies:
+    - https://github.com/magento/magento2/blob/develop/composer.json
+    - https://github.com/magento/magento-composer-installer/blob/master/composer.json
 description: |
     Magento offers flexible, scalable eCommerce solutions designed to help
     you grow and succeed online. Our cost-effective technology platform

--- a/projects/mautic.yml
+++ b/projects/mautic.yml
@@ -1,25 +1,7 @@
 name: Mautic
 url: https://www.mautic.org
-components:
-    - ClassLoader
-    - Config
-    - Console
-    - Debug
-    - DependencyInjection
-    - EventDispatcher
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Intl
-    - OptionsResolver
-    - Process
-    - Routing
-    - Security
-    - Templating
-    - Translation
-    - Validator
-    - Yaml
+dependencies:
+    - https://github.com/mautic/mautic/blob/master/composer.json
 description: |
     Mautic revolutionizes marketing automation. Mautic is an open source
     software tool available to every business regardless of their size

--- a/projects/morfeu.yml
+++ b/projects/morfeu.yml
@@ -1,42 +1,7 @@
 name: Morfeu
 url: https://github.com/leonardorifeli/morfeu
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/leonardorifeli/morfeu/blob/master/composer.json
 description: |
     Morfeu is a personal finance management system. Its robust code base enables
     easy and fast change.

--- a/projects/mothership.yml
+++ b/projects/mothership.yml
@@ -1,20 +1,7 @@
 name: Mothership
 url: http://mothership.ec
-components:
-  - Console
-  - EventDispatcher
-  - Filesystem
-  - Finder
-  - Form
-  - HttpKernel
-  - Process
-  - Routing
-  - Templating
-  - Translation
-  - TwigBridge
-  - TwigBundle
-  - Validator
-  - Yaml
+dependencies:
+  - https://github.com/mothership-ec/cog/blob/develop/composer.json
 description: |
     Mothership is open source web retail software, combining e-commerce with
     Electronic Point of Sale (EPOS) into a single, unified platform with a

--- a/projects/orocrm.yml
+++ b/projects/orocrm.yml
@@ -1,42 +1,8 @@
 name: OroCRM
 url: http://orocrm.com
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/orocrm/crm/blob/master/composer.json
+    - https://github.com/orocrm/platform/blob/master/composer.json
 description: |
     OroCRM is an easy-to-use, open source CRM with built-in marketing
     tools for your ecommerce business. It's the CRM both marketing and

--- a/projects/pagekit.yml
+++ b/projects/pagekit.yml
@@ -1,14 +1,7 @@
 name: Pagekit
 url: http://pagekit.com
-components:
-    - Console
-    - Debug
-    - Finder
-    - HttpFoundation
-    - Routing
-    - Stopwatch
-    - Templating
-    - Translation
+dependencies:
+    - https://github.com/pagekit/pagekit/blob/develop/composer.json
 description: |
     Pagekit is a modular and lightweight CMS built from the ground up with a
     modern architecture in mind. It serves as a web application framework

--- a/projects/pdepend.yml
+++ b/projects/pdepend.yml
@@ -1,9 +1,7 @@
 name: PHP Depend
 url: http://pdepend.org/
-components:
-    - Config
-    - DependencyInjection
-    - Filesystem
+dependencies:
+    - https://github.com/pdepend/pdepend/blob/master/composer.json
 description: |
     PHP_Depend is a small program that performs static code analysis on a
     given source base. It first takes the source code and parses it into an

--- a/projects/phinx.yml
+++ b/projects/phinx.yml
@@ -1,10 +1,7 @@
 name: Phinx
 url: http://phinx.org
-components:
-    - ClassLoader
-    - Config
-    - Console
-    - Yaml
+dependencies:
+    - https://github.com/cakephp/phinx/blob/master/composer.json
 description: |
     Phinx makes it ridiculously easy to manage the database migrations for
     your PHP app. In less than 5 minutes you can install Phinx and create

--- a/projects/phpbb.yml
+++ b/projects/phpbb.yml
@@ -1,21 +1,7 @@
 name: phpBB
 url: http://phpbb.com
-components:
-    - BrowserKit
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - EventDispatcher
-    - Filesystem
-    - Finder
-    - HttpFoundation
-    - HttpKernel
-    - Process
-    - Routing
-    - Yaml
+dependencies:
+    - https://github.com/phpbb/phpbb/blob/master/phpBB/composer.json
 description: |
     phpBB is a free flat-forum bulletin board software solution that can be
     used to stay in touch with a group of people or can power your entire

--- a/projects/phpdocumentor.yml
+++ b/projects/phpdocumentor.yml
@@ -1,9 +1,7 @@
 name: phpDocumentor
 url: http://phpdoc.org
-components:
-    - Config
-    - EventDispatcher
-    - Stopwatch
+dependencies:
+    - https://github.com/phpDocumentor/phpDocumentor2/blob/develop/composer.json
 description: |
     phpDocumentor 2 is a tool with which it is possible to generate
     documentation from your PHP source code. With this documentation you

--- a/projects/phpmyadmin.yml
+++ b/projects/phpmyadmin.yml
@@ -1,8 +1,8 @@
 name: phpMyAdmin
 url: https://www.phpmyadmin.net
-components:
-    - ExpressionLanguage
-    - 'Polyfill Mbstring'
+dependencies:
+    - https://github.com/phpmyadmin/phpmyadmin/blob/master/composer.json
+    - https://github.com/phpmyadmin/motranslator/blob/master/composer.json
 description: |
     phpMyAdmin is a web interface for MySQL and MariaDB. It allows to create,
     copy, drop, rename and alter databases, tables, views, fields and indexes.

--- a/projects/phpmyfaq.yml
+++ b/projects/phpmyfaq.yml
@@ -1,8 +1,7 @@
 name: phpMyFAQ
 url: http://phpmyfaq.de
-components:
-    - ClassLoader
-    - HttpFoundation
+dependencies:
+    - https://github.com/thorsten/phpMyFAQ/blob/master/composer.json
 description: |
     phpMyFAQ is a multilingual, database-driven FAQ-system. It supports
     various databases and PHP 5.2 (or higher). phpMyFAQ also offers a

--- a/projects/phpredexpert.yml
+++ b/projects/phpredexpert.yml
@@ -1,42 +1,7 @@
 name: phpRedExpert
 url: https://github.com/eugef/phpRedExpert
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/eugef/phpRedExpert/blob/master/composer.json
 description: |
     phpRedExpert is a lightweight and powerful web tool for Redis key-value
     store management and administration. It allows you to manage keys, monitor

--- a/projects/phpspec.yml
+++ b/projects/phpspec.yml
@@ -1,10 +1,7 @@
 name: phpspec
 url: http://www.phpspec.net/
-components:
-    - Console
-    - EventDispatcher
-    - Finder
-    - Yaml
+dependencies:
+    - https://github.com/phpspec/phpspec/blob/master/composer.json
 description: |
     phpspec is a tool which can help you write clean and working PHP code
     using behaviour driven development or BDD. It's also a PHP toolset to

--- a/projects/pimcore.yml
+++ b/projects/pimcore.yml
@@ -1,42 +1,7 @@
 name: Pimcore
 url: https://www.pimcore.org/
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/pimcore/pimcore/blob/master/composer.json
 description: |
     Pimcore is a platform for managing digital experiences. It is a
     consolidated platform for content, community and commerce across all

--- a/projects/piwik.yml
+++ b/projects/piwik.yml
@@ -1,10 +1,7 @@
 name: Piwik
 url: http://piwik.org/
-components:
-    - Console
-    - EventDispatcher
-    - VarDumper
-    - Yaml
+dependencies:
+    - https://github.com/piwik/piwik/blob/3.x-dev/composer.json
 description: |
     Piwik is the leading open source web analytics platform that gives you
     valuable insights on your website's visitors, your marketing campaigns

--- a/projects/ppi.yml
+++ b/projects/ppi.yml
@@ -1,13 +1,7 @@
 name: PPI Framework
 url: http://ppi.io
-components:
-    - ClassLoader
-    - Config
-    - Console
-    - HttpFoundation
-    - Routing
-    - Templating
-    - Yaml
+dependencies:
+    - https://github.com/ppi/framework/blob/master/composer.json
 description: |
     PPI is an open source php meta-framework. We have taken the good bits
     from Symfony, ZendFramework2 &amp; Doctrine2 and combined them together

--- a/projects/prestashop.yml
+++ b/projects/prestashop.yml
@@ -1,42 +1,7 @@
 name: PrestaShop
 url: https://www.prestashop.com/
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/PrestaShop/PrestaShop/blob/develop/composer.json
 description: |
     PrestaShop is an Open Source e-commerce solution used by more than
     250,000 online stores. PrestaShop is simple, efficient and intuitive,

--- a/projects/propel.yml
+++ b/projects/propel.yml
@@ -1,11 +1,7 @@
 name: Propel
 url: http://propelorm.org
-components:
-    - Console
-    - Filesystem
-    - Finder
-    - Validator
-    - Yaml
+dependencies:
+    - https://github.com/propelorm/Propel2/blob/master/composer.json
 description: |
     Propel is an open-source Object-Relational Mapping (ORM) for SQL-
     Databases in PHP 5.4. It allows you to access your database using a

--- a/projects/ratchet.yml
+++ b/projects/ratchet.yml
@@ -1,8 +1,7 @@
 name: Ratchet
 url: http://socketo.me/
-components:
-    - HttpFoundation
-    - Routing
+dependencies:
+    - https://github.com/ratchetphp/Ratchet/blob/master/composer.json
 description: |
     A PHP library for asynchronously serving WebSockets. Build up your
     application through simple interfaces and re-use your application without

--- a/projects/redkitecms.yml
+++ b/projects/redkitecms.yml
@@ -1,42 +1,7 @@
 name: RedKite CMS
 url: http://redkite-labs.com
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/redkite-labs/RedKiteCms/blob/master/composer.json
 description: |
     RedKite CMS is a content management system built on top of Symfony and
     Twitter-Bootstrap frameworks. You will be able to manage the content of

--- a/projects/roadiz.yml
+++ b/projects/roadiz.yml
@@ -1,23 +1,7 @@
 name: Roadiz
 url: http://www.roadiz.io
-components:
-    - Yaml
-    - Console
-    - HttpFoundation
-    - Routing
-    - Config
-    - HttpKernel
-    - Stopwatch
-    - Form
-    - Validator
-    - SecurityCsrf
-    - TwigBridge
-    - Finder
-    - Serializer
-    - FileSystem
-    - Security
-    - EventDispatcher
-    - Translation
+dependencies:
+    - https://github.com/roadiz/roadiz/blob/master/composer.json
 description: |
     Roadiz is a modern CMS based on a polymorphic node system which can
     handle many types of services and contents. Its back-office has been

--- a/projects/rocketeer.yml
+++ b/projects/rocketeer.yml
@@ -1,13 +1,7 @@
 name: Rocketeer
 url: http://rocketeer.autopergamene.eu/
-components:
-    - ClassLoader
-    - Config
-    - Console
-    - Finder
-    - Process
-    - VarDumper
-    - Yaml
+dependencies:
+    - https://github.com/rocketeers/rocketeer/blob/develop/composer.json
 description: |
     Rocketeer is a modern PHP task runner and deployment package. Emphasis is put
     on smart defaults and modern development. While it is coded in PHP, it can

--- a/projects/sami.yml
+++ b/projects/sami.yml
@@ -1,11 +1,7 @@
 name: Sami
 url: http://github.com/fabpot/sami
-components:
-    - Console
-    - Filesystem
-    - Finder
-    - Process
-    - Yaml
+dependencies:
+    - https://github.com/FriendsOfPHP/Sami/blob/master/composer.json
 description: |
     Sami is an API documentation generator. It uses a PHP file for
     configuration to give a very flexible way of tweaking the API

--- a/projects/sculpin.yml
+++ b/projects/sculpin.yml
@@ -1,16 +1,7 @@
 name: Sculpin
 url: https://sculpin.io
-components:
-    - ClassLoader
-    - Config
-    - Console
-    - DependencyInjection
-    - EventDispatcher
-    - Filesystem
-    - Finder
-    - HttpKernel
-    - Process
-    - Yaml
+dependencies:
+    - https://github.com/sculpin/sculpin/blob/master/composer.json
 description: |
     Sculpin is a static site generator written in PHP. It converts Markdown
     files and formats Twig templates into a set of static HTML files that

--- a/projects/shopware.yml
+++ b/projects/shopware.yml
@@ -1,18 +1,7 @@
 name: Shopware
 url: http://shopware.de
-components:
-    - ClassLoader
-    - Config
-    - Console
-    - DependencyInjection
-    - DomCrawler
-    - Finder
-    - Filesystem
-    - Form
-    - HttpKernel
-    - Process
-    - Routing
-    - Validator
+dependencies:
+    - https://github.com/shopware/shopware/blob/5.2/composer.json
 description: |
     Shopware is a complete eCommerce solution, combining a full range of
     functionality with a masterfully crafted simplistic design suitable

--- a/projects/silex.yml
+++ b/projects/silex.yml
@@ -1,29 +1,7 @@
 name: Silex
 url: http://silex.sensiolabs.org
-components:
-    - Asset
-    - BrowserKit
-    - Config
-    - CssSelector
-    - Debug
-    - DomCrawler
-    - EventDispatcher
-    - ExpressionLanguage
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Intl
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - Process
-    - Routing
-    - Security
-    - Serializer
-    - Translation
-    - Validator
-    - VarDumper
-    - WebLink
+dependencies:
+    - https://github.com/silexphp/Silex/blob/master/composer.json
 description: |
     Silex is a PHP microframework built on the shoulders of Symfony and Pimple
     and also inspired by Sinatra. A microframework provides the guts for

--- a/projects/silverstripe.yml
+++ b/projects/silverstripe.yml
@@ -1,10 +1,7 @@
 name: SilverStripe
 url: https://www.silverstripe.org
-components:
-    - Cache
-    - Config
-    - Translation
-    - Yaml
+dependencies:
+    - https://github.com/silverstripe/silverstripe-framework/blob/master/composer.json
 description: |
     SilverStripe is the intuitive content management system and flexible
     framework loved by editors and developers alike. Equip your web teams to

--- a/projects/sismo.yml
+++ b/projects/sismo.yml
@@ -1,14 +1,7 @@
 name: Sismo
 url: http://sismo.sensiolabs.org
-components:
-    - BrowserKit
-    - ClassLoader
-    - Console
-    - CssSelector
-    - DomCrawler
-    - Filesystem
-    - Finder
-    - Process
+dependencies:
+    - https://github.com/FriendsOfPHP/Sismo/blob/master/composer.json
 description: |
     Sismo is a Continuous Testing Server written in PHP. Sismo does not try
     to do more than getting your code, running your tests, and send you

--- a/projects/sonataecommerce.yml
+++ b/projects/sonataecommerce.yml
@@ -1,12 +1,7 @@
 name: Sonata e-commerce
 url: https://sonata-project.org/bundles/ecommerce/develop/doc/index.html
-components:
-    - Config
-    - Form
-    - Validator
-    - Routing
-    - Console
-    - Process
+dependencies:
+    - https://github.com/sonata-project/ecommerce/blob/master/composer.json
 description: |
     Sonata e-commerce is a group of Symfony bundles &amp; PHP components
     allowing you to add e-commerce capabilities to your Symfony

--- a/projects/sonataproject.yml
+++ b/projects/sonataproject.yml
@@ -1,42 +1,8 @@
 name: Sonata Project
 url: http://sonata-project.org
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/sonata-project/SonataCoreBundle/blob/master/composer.json
+    - https://github.com/sonata-project/SonataAdminBundle/blob/master/composer.json
 description: |
     The goal of the Sonata Project is to provide a set of high-level
     features built on top of the Symfony framework, with a strong focus on

--- a/projects/spress.yml
+++ b/projects/spress.yml
@@ -1,11 +1,7 @@
 name: Spress
 url: http://spress.yosymfony.com/
-components:
-    - Console
-    - EventDispatcher
-    - Filesystem
-    - Finder
-    - Yaml
+dependencies:
+    - https://github.com/spress/Spress/blob/master/composer.json
 description: |
     Spress is a static site generator built with Symfony components.
     Spress allows you to create and deploy blogs, personal websites,

--- a/projects/sulu.yml
+++ b/projects/sulu.yml
@@ -1,42 +1,7 @@
 name: Sulu
 url: http://sulu.io
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/sulu/sulu/blob/develop/composer.json
 description: |
     Sulu is a content management platform based on Symfony made for
     businesses. It's a flexible CMS to create and manage enterprise

--- a/projects/sylius.yml
+++ b/projects/sylius.yml
@@ -1,42 +1,7 @@
 name: Sylius
 url: http://sylius.org
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/Sylius/Sylius/blob/master/composer.json
 description: |
     Sylius is an open source e-commerce solution for PHP, based on the
     Symfony framework. Ultimate goal of the project is to create a webshop

--- a/projects/symfonycmf.yml
+++ b/projects/symfonycmf.yml
@@ -1,42 +1,9 @@
 name: Symfony CMF
 url: http://cmf.symfony.com
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/symfony-cmf/core-bundle/blob/master/composer.json
+    - https://github.com/symfony-cmf/routing/blob/master/composer.json
+    - https://github.com/symfony-cmf/standard-edition/blob/master/composer.json
 description: |
     The Symfony CMF project makes it easier for developers to add CMS
     functionality to applications built with the Symfony PHP framework.

--- a/projects/symfonyfs.yml
+++ b/projects/symfonyfs.yml
@@ -1,42 +1,7 @@
 name: Symfony
 url: https://symfony.com
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/symfony/symfony/blob/master/composer.json
 description: |
     Symfony is an Open Source PHP Web applications development framework.
     It was originally conceived by the interactive agency SensioLabs for

--- a/projects/thelia.yml
+++ b/projects/thelia.yml
@@ -1,23 +1,7 @@
 name: Thelia
 url: http://thelia.net
-components:
-    - BrowserKit
-    - ClassLoader
-    - Config
-    - Console
-    - DependencyInjection
-    - EventDispatcher
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoudation
-    - HttpKernel
-    - Icu
-    - Routing
-    - Serializer
-    - Translation
-    - Validator
-    - Yaml
+dependencies:
+    - https://github.com/thelia/thelia/blob/master/composer.json
 description: |
     Thelia is a tool for creating e-commerce websites and for online
     content management, published under General Public License. Thelia

--- a/projects/typo3.yml
+++ b/projects/typo3.yml
@@ -1,9 +1,7 @@
 name: TYPO3
 url: https://typo3.org/
-components:
-    - Console
-    - Finder
-    - Yaml
+dependencies:
+    - https://github.com/TYPO3/TYPO3.CMS/blob/master/composer.json
 description: |
     TYPO3 is an open source PHP based web content management system released
     under the GNU GPL.

--- a/projects/victoire.yml
+++ b/projects/victoire.yml
@@ -1,42 +1,7 @@
 name: Victoire CMS
 url: https://victoire.io/
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/Victoire/victoire/blob/master/composer.json
 description: |
     Victoire is an open source content management system based on the full
     stack Symfony framework and built to create complex custom websites.

--- a/projects/wallabag.yml
+++ b/projects/wallabag.yml
@@ -1,42 +1,7 @@
 name: Wallabag
 url: https://wallabag.org/
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/wallabag/wallabag/blob/master/composer.json
 description: |
     Wallabag is an Open Source read-it-later application. It saves the content
     of web pages to read them later anywhere: your browser, your RSS reader,

--- a/projects/wellcommerce.yml
+++ b/projects/wellcommerce.yml
@@ -1,42 +1,7 @@
 name: WellCommerce
 url: http://wellcommerce.org
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    - https://github.com/WellCommerce/WellCommerce/blob/master/composer.json
 description: |
     WellCommerce is a modern open source e-commerce platform, which has been
     created from scratch on Symfony Full-stack framework, with a background

--- a/projects/wpcli.yml
+++ b/projects/wpcli.yml
@@ -1,16 +1,7 @@
 name: WP-CLI
 url: https://wp-cli.org/
-components:
-    - Config
-    - Console
-    - Debug
-    - DependencyInjection
-    - EventDispatcher
-    - Filesystem
-    - Finder
-    - Process
-    - Translation
-    - Yaml
+dependencies:
+    - https://github.com/wp-cli/wp-cli/blob/master/composer.json
 description: |
     WP-CLI is a set of command-line tools for managing WordPress installations.
     You can update plugins, configure multisite installs and much more, without

--- a/projects/zikula.yml
+++ b/projects/zikula.yml
@@ -1,42 +1,9 @@
 name: Zikula
 url: http://zikula.de
-components:
-    - Asset
-    - BrowserKit
-    - Cache
-    - Config
-    - Console
-    - CssSelector
-    - Debug
-    - DependencyInjection
-    - DomCrawler
-    - Dotenv
-    - EventDispatcher
-    - ExpressionLanguage
-    - Filesystem
-    - Finder
-    - Form
-    - HttpFoundation
-    - HttpKernel
-    - Locale
-    - Intl
-    - Ldap
-    - Lock
-    - OptionsResolver
-    - "PHPUnit Bridge"
-    - "Polyfill APCu"
-    - Process
-    - PropertyAccess
-    - Routing
-    - Security
-    - Serializer
-    - Stopwatch
-    - Templating
-    - Translation
-    - Validator
-    - WebLink
-    - Workflow
-    - Yaml
+dependencies:
+    # don't use https://github.com/zikula/core/blob/1.5/composer.json because
+    # those dependencies are merged during runtime using a Composer plugin
+    - https://github.com/zikula/Wizard/blob/master/composer.json
 description: |
     Zikula is a Web Application Toolkit, which allows you to run
     impressive websites and build powerful online applications. Zikula has


### PR DESCRIPTION
Instead of listing the components, we now list the composer.json files and to scan them periodically to keep dependencies always updated without effort.


A few projects haven't been updated because they are abandoned and I'm going to remove them in a separate PR.